### PR TITLE
Temporary fix for paths-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import AbstractChart from './src/abstract-chart'
 import LineChart from './src/line-chart'
 import BarChart from './src/bar-chart'


### PR DESCRIPTION
Looks like babel-polyfill is already in deps so why not 
Related issue -> https://github.com/indiespirit/react-native-chart-kit/issues/29