### PR TITLE
fix NaN label when all values are the same

### DIFF
--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -39,7 +39,7 @@ class AbstractChart extends Component {
           y={(height * 3 / 4) - ((height - paddingTop) / count * i) + 12}
           fontSize={12}
           fill={this.props.chartConfig.color(0.5)}
-        >{(((Math.max(...data) - Math.min(...data)) / (count - 1) * i) + Math.min(...data)).toFixed(decimalPlaces)}
+        >{count === 1 ? data[0].toFixed(2) : (((Math.max(...data) - Math.min(...data)) / (count - 1)) * i + Math.min(...data)).toFixed(2)}
         </Text>
       )
     })


### PR DESCRIPTION
fixed issue #27 
- horizontal lable becomes NaN if all values are the same

in renderHorizontalLabels
count === 1 when all values are same
and thus denominator becomes zero
