### PR TITLE
fixed the issue of bar height and labels when all data are 0

### DIFF
--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -9,6 +9,8 @@ import {
 } from 'react-native-svg'
 
 class AbstractChart extends Component {
+  calcScaler = data => (Math.max(...data) - Math.min(...data)) || 1
+
   renderHorizontalLines = config => {
     const { count, width, height, paddingTop, paddingRight } = config
     return [...new Array(count)].map((_, i) => {
@@ -39,7 +41,7 @@ class AbstractChart extends Component {
           y={(height * 3 / 4) - ((height - paddingTop) / count * i) + 12}
           fontSize={12}
           fill={this.props.chartConfig.color(0.5)}
-        >{count === 1 ? data[0].toFixed(2) : (((Math.max(...data) - Math.min(...data)) / (count - 1)) * i + Math.min(...data)).toFixed(2)}
+        >{count === 1 ? data[0].toFixed(2) : ((this.calcScaler(data) / (count - 1)) * i + Math.min(...data)).toFixed(2)}
         </Text>
       )
     })

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -12,7 +12,7 @@ class BarChart extends AbstractChart {
   renderBars = config => {
     const { data, width, height, paddingTop, paddingRight } = config
     return data.map((x, i) => {
-      const barHeight = height / 4 * 3 * ((x - Math.min(...data)) / (Math.max(...data) - Math.min(...data)))
+      const barHeight = height / 4 * 3 * ((x - Math.min(...data)) / this.calcScaler(data))
       const barWidth = 32
       return (
         <Rect
@@ -29,7 +29,7 @@ class BarChart extends AbstractChart {
   renderBarTops = config => {
     const { data, width, height, paddingTop, paddingRight } = config
     return data.map((x, i) => {
-      const barHeight = height / 4 * 3 * ((x - Math.min(...data)) / (Math.max(...data) - Math.min(...data)))
+      const barHeight = height / 4 * 3 * ((x - Math.min(...data)) / this.calcScaler(data))
       return (
         <Rect
           key={Math.random()}

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -12,7 +12,6 @@ import {
 import AbstractChart from './abstract-chart'
 
 class LineChart extends AbstractChart {
-  calcScaler = data => (Math.max(...data) - Math.min(...data)) || 1
 
   renderDots = config => {
     const { data, width, height, paddingTop, paddingRight } = config


### PR DESCRIPTION
move `calcScaler = data => (Math.max(...data) - Math.min(...data)) || 1` to abstract-chart.js so that it can be used by more components

using `calcScaler` to prevent 0