### PR TITLE
fix for #63

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lodash": "^4.17.10",
     "paths-js": "^0.4.7",
     "point-in-polygon": "^1.0.1",
-    "react-native-scrollable-tab-view": "^0.8.0"
+    "react-native-scrollable-tab-view": "^0.8.0",
+    "babel-plugin-module-resolver": "^3.1.1"
   },
   "xo": {
     "extends": "xo-react",


### PR DESCRIPTION
might fix #63 . It worked locally in my terminal and expo app (^31.0.2), but adding babel-plugin-module-resolver to the dependencies might work as fine