### PR TITLE
[fix] Y labels value for multi lines

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -159,7 +159,7 @@ class LineChart extends AbstractChart {
       width,
       height
     }
-
+    const datas = data.datasets.reduce((acc, item) => item.data ? [...acc, ...item.data] : acc,[])
     return (
       <View style={style}>
         <Svg
@@ -197,7 +197,7 @@ class LineChart extends AbstractChart {
               ...config,
               count: (Math.min(...data.datasets[0].data) === Math.max(...data.datasets[0].data)) ?
                 1 : 4,
-              data: data.datasets[0].data,
+              data: datas,
               paddingTop,
               paddingRight
             })}


### PR DESCRIPTION
Fix display incorrect  Y values for multi lines
Was : 
![13 08 57](https://user-images.githubusercontent.com/47596337/52710031-fd226380-2f96-11e9-91ee-1844b4839e83.png)
Now : 
![13 08 25](https://user-images.githubusercontent.com/47596337/52710038-01e71780-2f97-11e9-9629-4c9bb9237609.png)
