### PR TITLE
Fix/y value for one dot

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -206,7 +206,7 @@ class LineChart extends AbstractChart {
             <G>
             {this.renderHorizontalLabels({
               ...config,
-              count: (Math.min(...data.datasets[0].data) === Math.max(...data.datasets[0].data)) ?
+              count: (Math.min(...datas) === Math.max(...datas)) ?
                 1 : 4,
               data: datas,
               paddingTop,


### PR DESCRIPTION
Fir display Y value for multi lines with one dot
Was. No display value for 30.94 : 
![16 29 47](https://user-images.githubusercontent.com/47596337/52793871-5feb2c00-3077-11e9-87e8-e9a83063fd69.png)

Now : 
![16 29 26](https://user-images.githubusercontent.com/47596337/52793898-70030b80-3077-11e9-8e6c-d8e92e0ee485.png)
