### PR TITLE
Add yAxisLabel prop to prepend text to horizontal labels.

### DIFF
--- a/App.js
+++ b/App.js
@@ -117,6 +117,7 @@ export default class App extends React.Component {
                 data={data}
                 width={width}
                 height={height}
+                yAxisLabel={'$'}
                 chartConfig={chartConfig}
                 style={graphStyle}
                 onDataPointClick={({value, getColor}) =>
@@ -141,6 +142,7 @@ export default class App extends React.Component {
                 width={width}
                 height={height}
                 data={data}
+                yAxisLabel={'$'}
                 chartConfig={chartConfig}
                 style={graphStyle}
               />
@@ -160,6 +162,7 @@ export default class App extends React.Component {
                 data={data}
                 width={width}
                 height={height}
+                yAxisLabel={'$'}
                 chartConfig={chartConfig}
                 style={graphStyle}
               />

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import {
     }}
     width={Dimensions.get('window').width} // from react-native
     height={220}
+    yAxisLabel={'$'}
     chartConfig={{
       backgroundColor: '#e26a00',
       backgroundGradientFrom: '#fb8c00',
@@ -120,6 +121,7 @@ const data = {
 | withShadow | boolean | Show shadow for line - default: True |
 | withInnerLines | boolean | Show inner dashed lines - default: True |
 | withOuterLines | boolean | Show outer dashed lines - default: True |
+| yAxisLabel | string | Prepend text to horizontal labels -- default: '' |
 | chartConfig | Object | Configuration object for the chart, see example config object above |
 |decorator | Function | This function takes a [whole bunch](https://github.com/indiespirit/react-native-chart-kit/blob/master/src/line-chart.js#L266) of stuff and can render extra elements, such as data point info or additional markup. |
 |onDataPointClick| Function| Callback that takes `{value, dataset, getColor}`|
@@ -184,6 +186,7 @@ const data = {
   data={data}
   width={screenWidth}
   height={220}
+  yAxisLabel={'$'}
   chartConfig={chartConfig}
 />
 ```
@@ -193,6 +196,7 @@ const data = {
 | data | Object | Data for the chart - see example above |
 | width | Number | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
 | height | Number | Height of the chart |
+| yAxisLabel | string | Prepend text to horizontal labels -- default: '' |
 | chartConfig | Object | Configuration object for the chart, see example config in the beginning of this file |
 
 ## Pie chart

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -47,8 +47,19 @@ class AbstractChart extends Component {
 
   renderHorizontalLabels = config => {
     const { count, data, height, paddingTop, paddingRight, yLabelsOffset = 12 } = config
-	var decimalPlaces = (this.props.chartConfig.decimalPlaces !== undefined) ? this.props.chartConfig.decimalPlaces : 2;
+    const decimalPlaces = this.props.chartConfig.decimalPlaces || 2;
+    const yAxisLabel = this.props.yAxisLabel || ''
+
     return [...new Array(count)].map((_, i) => {
+      let yLabel;
+
+      if(count === 1){ 
+        yLabel = `${yAxisLabel}${data[0].toFixed(decimalPlaces)}`
+      }else {
+       const label = (this.calcScaler(data) / (count - 1)) * i + Math.min(...data)
+       yLabel = `${yAxisLabel}${label.toFixed(decimalPlaces)}`
+      }
+
       return (
         <Text
           key={Math.random()}
@@ -57,7 +68,7 @@ class AbstractChart extends Component {
           y={(height * 3 / 4) - ((height - paddingTop) / count * i) + 12}
           fontSize={12}
           fill={this.props.chartConfig.color(0.5)}
-        >{count === 1 ? data[0].toFixed(decimalPlaces) : ((this.calcScaler(data) / (count - 1)) * i + Math.min(...data)).toFixed(decimalPlaces)}
+        >{yLabel}
         </Text>
       )
     })


### PR DESCRIPTION
1) Add yAxisLabel prop to prepend text to horizontal labels.
2) Refactor decimalPlaces in renderHorizontalLabels (easier to read).
3) Updated App.js and README.md to show the use of yAxisLabel.

Related issue: #30