### PR TITLE
Fix PieChart to be able to be rendered

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -55,7 +55,7 @@ class PieChart extends AbstractChart {
               12 * 2
             }
           >
-            {value} {c.item.name}
+            {`${value} ${c.item.name}`}
           </Text>
         </G>
       )


### PR DESCRIPTION
In v2.4.0, when running `yarn start`, `App.js` doesn't render anything without any error, so I fix this problem with this MR.

However, I couldn't find any related issue. If you could reproduce this problem by running `yarn start` in v2.4.0, please make sure that this problem can be solved by this MR?

The environment where the problem was found is as follows.

* OS: OSX 10.14.3
* expo: 2.13.0
* Xcode: 10.1
* Simulator: iOS 12.1, iPhone 8
* Node: v8.10.0