### PR TITLE
Fix BarChart that has negative value

### DIFF
--- a/data.js
+++ b/data.js
@@ -4,7 +4,7 @@ const data = {
   labels: ['January', 'February', 'March', 'April', 'May', 'June'],
   datasets: [
     {
-      data: [50, 20, 2, 86, 71, 100],
+      data: [-50, -20, -2, 86, 71, 100],
       color: (opacity = 1) => `rgba(134, 65, 244, ${opacity})` // optional
     },
     {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "react-test-renderer": "16.7.0",
     "xo": "^0.24.0"
   },
-  "main": "./node_modules/expo/AppEntry.js",
-  "_main": "./index.js",
+  "_main": "./node_modules/expo/AppEntry.js",
+  "main": "./index.js",
   "scripts": {
     "start": "expo start",
     "eject": "expo eject",

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -8,9 +8,9 @@ const barWidth = 32
 class BarChart extends AbstractChart {
   renderBars = config => {
     const {data, width, height, paddingTop, paddingRight} = config
+    const baseHeight = (height / 4 * 3) * (Math.max(...data) / this.calcScaler(data)) + paddingTop
     return data.map((x, i) => {
-      const barHeight =
-        (height / 4) * 3 * ((x - Math.min(...data)) / this.calcScaler(data))
+      const barHeight = height / 4 * 3 * (x / this.calcScaler(data))
       const barWidth = 32
       return (
         <Rect
@@ -20,7 +20,7 @@ class BarChart extends AbstractChart {
             (i * (width - paddingRight)) / data.length +
             barWidth / 2
           }
-          y={(height / 4) * 3 - barHeight + paddingTop}
+          y={baseHeight - barHeight}
           width={barWidth}
           height={barHeight}
           fill="url(#fillShadowGradient)"
@@ -31,9 +31,9 @@ class BarChart extends AbstractChart {
 
   renderBarTops = config => {
     const {data, width, height, paddingTop, paddingRight} = config
+    const baseHeight = (height / 4 * 3) * (Math.max(...data) / this.calcScaler(data)) + paddingTop
     return data.map((x, i) => {
-      const barHeight =
-        (height / 4) * 3 * ((x - Math.min(...data)) / this.calcScaler(data))
+      const barHeight = height / 4 * 3 * (x / this.calcScaler(data))
       return (
         <Rect
           key={Math.random()}
@@ -42,7 +42,7 @@ class BarChart extends AbstractChart {
             (i * (width - paddingRight)) / data.length +
             barWidth / 2
           }
-          y={(height / 4) * 3 - barHeight + paddingTop}
+          y={baseHeight - barHeight}
           width={barWidth}
           height={2}
           fill={this.props.chartConfig.color(0.6)}


### PR DESCRIPTION
If the data in `BarChart` is like below,

```js
<BarChart
  width={width}
  height={height}
  data={[-50, -20, -2, 86, 71, 100]}
  chartConfig={chartConfig}
  style={graphStyle}
/>
```

currently the bar chart is rendered as follow.

![current-bar-chart](https://user-images.githubusercontent.com/18485918/55327694-9cf36c80-54c5-11e9-8f05-c829c898ae3d.png)

It's not correct bar chart. The negative numbers are usually rendered like below, thus I fixed it in this MR.

![fixed-bar-chart](https://user-images.githubusercontent.com/18485918/55327695-9ebd3000-54c5-11e9-9351-37334cd70760.png)

Related issue: https://github.com/indiespirit/react-native-chart-kit/issues/93
