### PR TITLE
Line graph on press fix

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
   "expo": {
-    "sdkVersion": "UNVERSIONED"
+    "sdkVersion": "32.0.0"
   }
 }

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -48,22 +48,23 @@ class LineChart extends AbstractChart {
         }
 
         output.push(
-          <View key={Math.random()}>
-            <Circle
-              cx={cx}
-              cy={cy}
-              r="4"
-              fill={this.getColor(dataset, 0.9)}
-              onPress={onPress}
-            />
-            <Circle
-              cx={cx}
-              cy={cy}
-              r="12"
-              fill={this.getColor(dataset, 0)}
-              onPress={onPress}
-            />
-          </View>
+          <Circle
+            key={Math.random()}
+            cx={cx}
+            cy={cy}
+            r="4"
+            fill={this.getColor(dataset, 0.9)}
+            onPress={onPress}
+          />,
+          <Circle
+            key={Math.random()}
+            cx={cx}
+            cy={cy}
+            r="12"
+            fill="#fff"
+            fillOpacity={0}
+            onPress={onPress}
+          />
         )
       })
     })


### PR DESCRIPTION
The current logic for the LineGraph component relies on the passed in dataSet color to use the opacity param in the function. If you want a solid color, and don't use the opacity param, this creates a huge dot on the screen. So I updated the larger click area dot, to not rely on the opacity of the passed in color, but set it on the circle itself.

I also noticed that pulling down the code and running it, the dots were not showing up on the line graph in iOS. I noticed this when I upgraded to the latest version in my project as well. iOS seems to not like the dots being inside a View, and removing them from that, seemed to work.

Last thing I updated was updating the app.json for development. If you don't have sdkVersion set, it uses the latest version installed (currently sdk 33 for me) instead of the one from package.json. This was throwing errors for me.