### PR TITLE
Fixes Pie Charts with empty values and single slice (#89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
-    "paths-js": "^0.4.7",
+    "paths-js": "^0.4.10",
     "point-in-polygon": "^1.0.1"
   },
   "xo": {

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -26,7 +26,11 @@ class PieChart extends AbstractChart {
       if (absolute) {
         value = c.item[this.props.accessor]
       } else {
-        value = Math.round((100 / total) * c.item[this.props.accessor]) + '%'
+        if (total === 0){
+          value = 0 + '%';
+        }else{
+          value = Math.round((100 / total) * c.item[this.props.accessor]) + '%';
+        }
       }
 
       return (


### PR DESCRIPTION
I noticed a problem with Pie Charts and empty data. I worked on a fix that also fixes another issue. I hope it helps more people facing the same problem. 

1. Pie Charts with empty values would crash the app

![IMG_2E8E62F8B344-1](https://user-images.githubusercontent.com/4614416/62667975-5eccf480-b960-11e9-8b6d-88c9dfacd8df.jpeg)

2. Pie Charts with one color would not displaying correclty ( Issue https://github.com/indiespirit/react-native-chart-kit/issues/89 )

![IMG_4144](https://user-images.githubusercontent.com/4614416/62667979-6391a880-b960-11e9-99ff-9f7c4fa158c0.PNG)


Notice: Updating paths-js to 0.4.10 fixed the crashing and issue 89. Some checking was necessary to prevent NaN labels on empty data.