### PR TITLE
Enables horizontal and vertical label rotations

### DIFF
--- a/App.js
+++ b/App.js
@@ -97,7 +97,7 @@ export default class App extends React.Component {
 
   render() {
     const {width} = Dimensions.get('window')
-    const height = 220
+    const height = 256
     return (
       <ScrollableTabView renderTabBar={this.renderTabBar}>
         {chartConfigs.map(chartConfig => {
@@ -127,6 +127,7 @@ export default class App extends React.Component {
                 yAxisLabel="$"
                 chartConfig={chartConfig}
                 style={graphStyle}
+                verticalLabelRotation={30}
                 onDataPointClick={({value, getColor}) =>
                   showMessage({
                     message: `${value}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.5.0
+- added `horizontalLabelRotation` and `verticalLabelRotation` props to `LineChart`
+
 ## v3.4.0
 - added `chartConfig` `backgroundGradientFromOpacity` and `backgroundGradientToOpacity`
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ const data = {
 | chartConfig | Object | Configuration object for the chart, see example config object above |
 |decorator | Function | This function takes a [whole bunch](https://github.com/indiespirit/react-native-chart-kit/blob/master/src/line-chart.js#L266) of stuff and can render extra elements, such as data point info or additional markup. |
 |onDataPointClick| Function| Callback that takes `{value, dataset, getColor}`|
+|horizontalLabelRotation| number| sets the rotation angle of the horizontal labels - default 0|
+|verticalLabelRotation| number| sets the rotation angle of the vertical labels - default 0|
 
 ## Bezier Line Chart
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ const data = {
 | yAxisLabel | string | Prepend text to horizontal labels -- default: '' |
 | chartConfig | Object | Configuration object for the chart, see example config object above |
 |decorator | Function | This function takes a [whole bunch](https://github.com/indiespirit/react-native-chart-kit/blob/master/src/line-chart.js#L266) of stuff and can render extra elements, such as data point info or additional markup. |
-|onDataPointClick| Function| Callback that takes `{value, dataset, getColor}`|
-|horizontalLabelRotation| number| sets the rotation angle of the horizontal labels - default 0|
-|verticalLabelRotation| number| sets the rotation angle of the vertical labels - default 0|
+|onDataPointClick| Function | Callback that takes `{value, dataset, getColor}`|
+|horizontalLabelRotation| number (degree) | Rotation angle of the horizontal labels - default 0|
+|verticalLabelRotation| number (degree) | Rotation angle of the vertical labels - default 0|
 
 ## Bezier Line Chart
 
@@ -144,7 +144,8 @@ const data = {
 <LineChart
   data={data}
   width={screenWidth}
-  height={220}
+  height={256}
+  verticalLabelRotation={30}
   chartConfig={chartConfig}
   bezier
 />

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -80,7 +80,8 @@ class AbstractChart extends Component {
       height,
       paddingTop,
       paddingRight,
-      yLabelsOffset = 12
+      yLabelsOffset = 12,
+      horizontalLabelRotation = 0
     } = config
     const decimalPlaces = this.props.chartConfig.decimalPlaces === undefined ? 2 : this.props.chartConfig.decimalPlaces
     const yAxisLabel = this.props.yAxisLabel || ''
@@ -97,12 +98,16 @@ class AbstractChart extends Component {
         yLabel = `${yAxisLabel}${label.toFixed(decimalPlaces)}`
       }
 
+      const x = paddingRight - yLabelsOffset
+      const y = (height * 3) / 4 - ((height - paddingTop) / count) * i + 12
       return (
         <Text
+          rotation={horizontalLabelRotation}
+          origin={`${x}, ${y}`}
           key={Math.random()}
-          x={paddingRight - yLabelsOffset}
+          x={x}
           textAnchor="end"
-          y={(height * 3) / 4 - ((height - paddingTop) / count) * i + 12}
+          y={y}
           fontSize={12}
           fill={this.props.chartConfig.color(0.5)}
         >
@@ -120,7 +125,8 @@ class AbstractChart extends Component {
       paddingRight,
       paddingTop,
       horizontalOffset = 0,
-      stackedBar = false
+      stackedBar = false,
+      verticalLabelRotation = 0
     } = config
     const fontSize = 12
     let fac = 1
@@ -129,19 +135,22 @@ class AbstractChart extends Component {
     }
 
     return labels.map((label, i) => {
+      const x =
+        (((width - paddingRight) / labels.length) * i +
+          paddingRight +
+          horizontalOffset) *
+        fac;
+      const y = (height * 3) / 4 + paddingTop + fontSize * 2;
       return (
         <Text
+          origin={`${x}, ${y}`}
+          rotation={verticalLabelRotation}
           key={Math.random()}
-          x={
-            (((width - paddingRight) / labels.length) * i +
-              paddingRight +
-              horizontalOffset) *
-            fac
-          }
-          y={(height * 3) / 4 + paddingTop + fontSize * 2}
+          x={x}
+          y={y}
           fontSize={fontSize}
           fill={this.props.chartConfig.color(0.5)}
-          textAnchor="middle"
+          textAnchor={verticalLabelRotation === 0 ? "middle" : "start"}
         >
           {label}
         </Text>

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -225,13 +225,17 @@ class LineChart extends AbstractChart {
       withVerticalLabels = true,
       style = {},
       decorator,
-      onDataPointClick
+      onDataPointClick,
+      verticalLabelRotation = 0,
+      horizontalLabelRotation = 0
     } = this.props
     const {labels = []} = data
     const {borderRadius = 0} = style
     const config = {
       width,
-      height
+      height,
+      verticalLabelRotation,
+      horizontalLabelRotation
     }
     const datas = this.getDatas(data.datasets)
     return (


### PR DESCRIPTION
This PR addresses #155 related issues of overlapping label text. Exposes a top-level interface for adjusting the rotation of either the vertical or horizontal labels. Open for feedback, would love to see this feature get incorporated!

![image](https://user-images.githubusercontent.com/11801873/65468983-6de20600-de2b-11e9-8bc4-b23882ca37e5.png)
