### PR TITLE
Adds dot color callback prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ const data = {
 |onDataPointClick| Function | Callback that takes `{value, dataset, getColor}`|
 |horizontalLabelRotation| number (degree) | Rotation angle of the horizontal labels - default 0|
 |verticalLabelRotation| number (degree) | Rotation angle of the vertical labels - default 0|
+|dotColor| function => string | Defines the dot color function that is used to calculate colors of dots in a line chart and takes `(dataPoint, dataPointIndex)`
 
 ## Bezier Line Chart
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export interface LineChartProps {
   onDataPointClick?: Function
   style?: object
   bezier?: boolean
+  dotColor?: (dataPoint: any, index: number) => string
 }
 
 export class LineChart extends React.Component<LineChartProps> {}

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -27,6 +27,7 @@ class LineChart extends AbstractChart {
     const output = []
     const datas = this.getDatas(data)
     const baseHeight = this.calcBaseHeight(datas, height)
+    const dotColor = this.props.dotColor || null
     data.map((dataset, index) => {
       dataset.data.map((x, i) => {
         const cx =
@@ -52,7 +53,7 @@ class LineChart extends AbstractChart {
             cx={cx}
             cy={cy}
             r="4"
-            fill={this.getColor(dataset, 0.9)}
+            fill={(dotColor && dotColor(x, i)) || this.getColor(dataset, 0.9)}
             onPress={onPress}
           />,
           <Circle

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -53,7 +53,7 @@ class LineChart extends AbstractChart {
             cx={cx}
             cy={cy}
             r="4"
-            fill={(dotColor && dotColor(x, i)) || this.getColor(dataset, 0.9)}
+            fill={typeof dotColor === 'function' ? dotColor(x, i) : this.getColor(dataset, 0.9)}
             onPress={onPress}
           />,
           <Circle


### PR DESCRIPTION
Backwards compatible change, enables coloring of any dot based on data point value or data point index in a line chart. Addresses #165 

![image](https://user-images.githubusercontent.com/11801873/65551923-9da31380-dee8-11e9-8cbf-31012882d49b.png)
