### PR TITLE
Added dot cx, cy in the onDataPointClick functions arguments & fixes for horizontal label position when there is only one data point and fromZero prop is ture

### DIFF
--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -108,7 +108,10 @@ class AbstractChart extends Component {
       }
 
       const x = paddingRight - yLabelsOffset;
-      const y = (height * 3) / 4 - ((height - paddingTop) / count) * i + 12;
+      const y =
+        count === 1 && this.props.fromZero
+          ? paddingTop + 4
+          : (height * 3) / 4 - ((height - paddingTop) / count) * i + 12;
       return (
         <Text
           rotation={horizontalLabelRotation}

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -52,6 +52,8 @@ class LineChart extends AbstractChart {
             index: i,
             value: x,
             dataset,
+            x: cx,
+            y: cy,
             getColor: opacity => this.getColor(dataset, opacity)
           });
         };


### PR DESCRIPTION
cx, cy is needed to show the tooltip for the dots in the chart.