### PR TITLE
feature: new dashed option for line charts

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -20,6 +20,10 @@ class LineChart extends AbstractChart {
     return dataset.strokeWidth || this.props.chartConfig.strokeWidth || 3;
   };
 
+  getStrokeDashedArray = dataset => {
+    return dataset.strokeDasharray || [];
+  };
+
   getDatas = data =>
     data.reduce((acc, item) => (item.data ? [...acc, ...item.data] : acc), []);
 
@@ -202,6 +206,7 @@ class LineChart extends AbstractChart {
         <Path
           key={index}
           d={result}
+          strokeDasharray={this.getStrokeDashedArray(dataset)}
           fill="none"
           stroke={this.getColor(dataset, 0.2)}
           strokeWidth={this.getStrokeWidth(dataset)}


### PR DESCRIPTION
This PR introduce a new feature that we can apply dashed styling to each dataset in line chart.

You can define the dataset as you were but now there is a new option **strokeDasharray**

In react-native-svg this option is where you define your line styling so i adopted the same logic and name to use it also here

Example below.

```
datasets: [
 {
	strokeDasharray: ['5', '25'],
	data: [
	  Math.random() * 100,
	  Math.random() * 100,
	  Math.random() * 100,
	  Math.random() * 100,
	  Math.random() * 100,
	  Math.random() * 100,
	  Math.random() * 100,
	],
  }
]            
```
<img width="539" alt="Screenshot 2019-11-15 at 09 32 30" src="https://user-images.githubusercontent.com/6433679/68925081-ebbaf180-078a-11ea-866b-0386a00fd892.png">
