### PR TITLE
Pass format function to Y and X labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.*
 package-lock.json
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -118,13 +118,15 @@ const screenWidth = Dimensions.get("window").width;
 
 ```js
 const data = {
-  labels: ['January', 'February', 'March', 'April', 'May', 'June'],
-  datasets: [{
-    data: [ 20, 45, 28, 80, 99, 43 ],
-    color: (opacity = 1) => `rgba(134, 65, 244, ${opacity})`, // optional
-    strokeWidth: 2 // optional
-  }]
-}
+  labels: ["January", "February", "March", "April", "May", "June"],
+  datasets: [
+    {
+      data: [20, 45, 28, 80, 99, 43],
+      color: (opacity = 1) => `rgba(134, 65, 244, ${opacity})`, // optional
+      strokeWidth: 2 // optional
+    }
+  ]
+};
 ```
 
 ```html
@@ -160,6 +162,9 @@ const data = {
 | yLabelsOffset           | number             | Offset for Y axis labels                                                                                                                                                                                            |
 | xLabelsOffset           | number             | Offset for X axis labels                                                                                                                                                                                            |
 | hidePointsAtIndex       | number[]           | Indices of the data points you don't want to display                                                                                                                                                                |
+| formatYLabel            | Function           | This function change the format of the display value of the Y label. Takes the y value as argument and should return the desirable string.                                                                          |
+
+| formatXLabel | Function | This function change the format of the display value of the X label. Takes the X value as argument and should return the desirable string. |
 
 ## Bezier Line Chart
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,8 @@ const data = {
 | yLabelsOffset           | number             | Offset for Y axis labels                                                                                                                                                                                            |
 | xLabelsOffset           | number             | Offset for X axis labels                                                                                                                                                                                            |
 | hidePointsAtIndex       | number[]           | Indices of the data points you don't want to display                                                                                                                                                                |
-| formatYLabel            | Function           | This function change the format of the display value of the Y label. Takes the y value as argument and should return the desirable string.                                                                          |
-
-| formatXLabel | Function | This function change the format of the display value of the X label. Takes the X value as argument and should return the desirable string. |
+| formatYLabel            | Function           | This function change the format of the display value of the Y label. Takes the Y value as argument and should return the desirable string.                                                                          |
+| formatXLabel            | Function           | This function change the format of the display value of the X label. Takes the X value as argument and should return the desirable string.                                                                          |
 
 ## Bezier Line Chart
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ export interface LineChartProps {
   yLabelsOffset?: number;
   xLabelsOffset?: number;
   hidePointsAtIndex?: number[];
+  formatYLabel?: (yValue: string) => string;
 }
 
 export class LineChart extends React.Component<LineChartProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,28 +6,136 @@ import * as React from "react";
 
 // LineChart
 export interface LineChartProps {
+  /**
+   * Data for the chart.
+   *
+   * Example from [docs](https://github.com/indiespirit/react-native-chart-kit#line-chart):
+   *
+   * ```javascript
+   * const data = {
+   *   labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+   *   datasets: [{
+   *     data: [ 20, 45, 28, 80, 99, 43 ],
+   *     color: (opacity = 1) => `rgba(134, 65, 244, ${opacity})`, // optional
+   *     strokeWidth: 2 // optional
+   *   }]
+   * }
+   * ```
+   */
   data: object;
+  /**
+   * Width of the chart, use 'Dimensions' library to get the width of your screen for responsive.
+   */
   width: number;
+  /**
+   * Height of the chart.
+   */
   height: number;
+  /**
+   * Show dots on the line - default: True.
+   */
   withDots?: boolean;
+  /**
+   * Show shadow for line - default: True.
+   */
   withShadow?: boolean;
+  /**
+   * Show inner dashed lines - default: True.
+   */
   withInnerLines?: boolean;
+  /**
+   * Show outer dashed lines - default: True.
+   */
   withOuterLines?: boolean;
+  /**
+   * Show vertical labels - default: True.
+   */
+  withVerticalLabels?: boolean;
+  /**
+   * Show horizontal labels - default: True.
+   */
+  withHorizontalLabels?: boolean;
+  /**
+   * Render charts from 0 not from the minimum value. - default: False.
+   */
   fromZero?: boolean;
+  /**
+   * Prepend text to horizontal labels -- default: ''.
+   */
   yAxisLabel?: string;
+  /**
+   * Append text to horizontal labels -- default: ''.
+   */
   yAxisSuffix?: string;
+  /**
+   * Prepend text to vertical labels -- default: ''.
+   */
   xAxisLabel?: string;
+  /**
+   * Configuration object for the chart, see example:
+   *
+   * ```javascript
+   * const chartConfig = {
+   *   backgroundGradientFrom: "#1E2923",
+   *   backgroundGradientFromOpacity: 0,
+   *   backgroundGradientTo: "#08130D",
+   *   backgroundGradientToOpacity: 0.5,
+   *   color: (opacity = 1) => `rgba(26, 255, 146, ${opacity})`,
+   *   strokeWidth: 2, // optional, default 3
+   *   barPercentage: 0.5
+   * };
+   * ```
+   */
   chartConfig: ChartConfig;
+  /**
+   * This function takes a [whole bunch](https://github.com/indiespirit/react-native-chart-kit/blob/master/src/line-chart.js#L266)
+   * of stuff and can render extra elements,
+   * such as data point info or additional markup.
+   */
   decorator?: Function;
+  /**
+   * Callback that takes as params: `{value, dataset, getColor}`.
+   */
   onDataPointClick?: Function;
+  /**
+   * Style of the container view of the chart.
+   */
   style?: object;
+  /**
+   * Add this prop to make the line chart smooth and curvy.
+   *
+   * [Example](https://github.com/indiespirit/react-native-chart-kit#bezier-line-chart)
+   */
   bezier?: boolean;
+  /**
+   * Defines the dot color function that is used to calculate colors of dots in a line chart.
+   * Takes `(dataPoint, dataPointIndex)` as arguments.
+   */
   getDotColor?: (dataPoint: any, index: number) => string;
+  /**
+   * Rotation angle of the horizontal labels - default 0 (degrees).
+   */
   horizontalLabelRotation?: number;
+  /**
+   * Rotation angle of the vertical labels - default 0 (degrees).
+   */
   verticalLabelRotation?: number;
+  /**
+   * Offset for Y axis labels.
+   */
   yLabelsOffset?: number;
+  /**
+   * Offset for X axis labels.
+   */
   xLabelsOffset?: number;
+  /**
+   * Array of indices of the data points you don't want to display.
+   */
   hidePointsAtIndex?: number[];
+  /**
+   * This function change the format of the display value of the Y label.
+   * Takes the y value as argument and should return the desirable string.
+   */
   formatYLabel?: (yValue: string) => string;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,8 +138,8 @@ export interface LineChartProps {
    */
   formatYLabel?: (yValue: string) => string;
   /**
-   * This function change the format of the display value of the x label.
-   * Takes the x value as argument and should return the desirable string.
+   * This function change the format of the display value of the X label.
+   * Takes the X value as argument and should return the desirable string.
    */
   formatXLabel?: (xValue: string) => string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,11 @@ export interface LineChartProps {
    * Takes the y value as argument and should return the desirable string.
    */
   formatYLabel?: (yValue: string) => string;
+  /**
+   * This function change the format of the display value of the x label.
+   * Takes the x value as argument and should return the desirable string.
+   */
+  formatXLabel?: (xValue: string) => string;
 }
 
 export class LineChart extends React.Component<LineChartProps> {}

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -102,18 +102,27 @@ class AbstractChart extends Component {
       horizontalLabelRotation = 0,
       formatYLabel = yLabel => yLabel
     } = config;
-    const { yAxisLabel = "", yAxisSuffix = "", yLabelsOffset = 12, chartConfig } = this.props;
+    const {
+      yAxisLabel = "",
+      yAxisSuffix = "",
+      yLabelsOffset = 12,
+      chartConfig
+    } = this.props;
     const { decimalPlaces = 2 } = chartConfig;
     return [...new Array(count)].map((_, i) => {
       let yLabel;
 
       if (count === 1) {
-        yLabel = `${yAxisLabel}${formatYLabel(data[0].toFixed(decimalPlaces))}${yAxisSuffix}`;
+        yLabel = `${yAxisLabel}${formatYLabel(
+          data[0].toFixed(decimalPlaces)
+        )}${yAxisSuffix}`;
       } else {
         const label = this.props.fromZero
           ? (this.calcScaler(data) / (count - 1)) * i + Math.min(...data, 0)
           : (this.calcScaler(data) / (count - 1)) * i + Math.min(...data);
-        yLabel = `${yAxisLabel}${formatYLabel(label.toFixed(decimalPlaces))}${yAxisSuffix}`;
+        yLabel = `${yAxisLabel}${formatYLabel(
+          label.toFixed(decimalPlaces)
+        )}${yAxisSuffix}`;
       }
 
       const x = paddingRight - yLabelsOffset;

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -155,7 +155,8 @@ class AbstractChart extends Component {
       paddingTop,
       horizontalOffset = 0,
       stackedBar = false,
-      verticalLabelRotation = 0
+      verticalLabelRotation = 0,
+      formatXLabel = xLabel => xLabel
     } = config;
     const {
       xAxisLabel = "",
@@ -187,7 +188,7 @@ class AbstractChart extends Component {
           textAnchor={verticalLabelRotation === 0 ? "middle" : "start"}
           {...this.getPropsForLabels()}
         >
-          {`${label}${xAxisLabel}`}
+          {`${formatXLabel(label)}${xAxisLabel}`}
         </Text>
       );
     });

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -99,7 +99,8 @@ class AbstractChart extends Component {
       height,
       paddingTop,
       paddingRight,
-      horizontalLabelRotation = 0
+      horizontalLabelRotation = 0,
+      formatYLabel = yLabel => yLabel
     } = config;
     const { yAxisLabel = "", yAxisSuffix = "", yLabelsOffset = 12, chartConfig } = this.props;
     const { decimalPlaces = 2 } = chartConfig;
@@ -107,12 +108,12 @@ class AbstractChart extends Component {
       let yLabel;
 
       if (count === 1) {
-        yLabel = `${yAxisLabel}${data[0].toFixed(decimalPlaces)}${yAxisSuffix}`;
+        yLabel = `${yAxisLabel}${formatYLabel(data[0].toFixed(decimalPlaces))}${yAxisSuffix}`;
       } else {
         const label = this.props.fromZero
           ? (this.calcScaler(data) / (count - 1)) * i + Math.min(...data, 0)
           : (this.calcScaler(data) / (count - 1)) * i + Math.min(...data);
-        yLabel = `${yAxisLabel}${label.toFixed(decimalPlaces)}${yAxisSuffix}`;
+        yLabel = `${yAxisLabel}${formatYLabel(label.toFixed(decimalPlaces))}${yAxisSuffix}`;
       }
 
       const x = paddingRight - yLabelsOffset;

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -246,7 +246,8 @@ class LineChart extends AbstractChart {
       onDataPointClick,
       verticalLabelRotation = 0,
       horizontalLabelRotation = 0,
-      formatYLabel = yLabel => yLabel
+      formatYLabel = yLabel => yLabel,
+      formatXLabel = xLabel => xLabel
     } = this.props;
     const { labels = [] } = data;
     const { borderRadius = 0, paddingTop = 16, paddingRight = 64 } = style;
@@ -325,7 +326,8 @@ class LineChart extends AbstractChart {
                     ...config,
                     labels,
                     paddingRight,
-                    paddingTop
+                    paddingTop,
+                    formatXLabel
                   })
                 : null}
             </G>

--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -245,7 +245,8 @@ class LineChart extends AbstractChart {
       decorator,
       onDataPointClick,
       verticalLabelRotation = 0,
-      horizontalLabelRotation = 0
+      horizontalLabelRotation = 0,
+      formatYLabel = yLabel => yLabel
     } = this.props;
     const { labels = [] } = data;
     const { borderRadius = 0, paddingTop = 16, paddingRight = 64 } = style;
@@ -297,7 +298,8 @@ class LineChart extends AbstractChart {
                     count: Math.min(...datas) === Math.max(...datas) ? 1 : 4,
                     data: datas,
                     paddingTop,
-                    paddingRight
+                    paddingRight,
+                    formatYLabel
                   })
                 : null}
             </G>


### PR DESCRIPTION
## Motivation
As described in #212 in my project I had a very particular use case, but maybe this could help others. As I mentioned in the issue, another libraries have a callback like that.

## What changed
- Add two props in the LinearChart(`formatYLabel` and `formatXLabel`) that receive functions with the label value as parameter and should return string.
- Update README with the new props description.
- As I was adding description to the props in `index.d.ts` I took the liberty to describe all LineChartProps based on the current docs info.

## Final thoughts
- I didn't remove `yAxisLabel`, `yAxisSuffix` and `xAxisLabel` props and this works with both approaches, but the `formatYLabel` and `formatXLabel` can be used to add prefix and suffix to the label as mentioned [here](https://github.com/indiespirit/react-native-chart-kit/pull/196#issuecomment-545726114), but again because of [this](https://github.com/indiespirit/react-native-chart-kit/issues/212#issuecomment-554050000) I didn't want to bring breaking changes.
- Changes made only in LinearChart.