### PR TITLE
Fix LineChart's decimalPlaces prop

### DIFF
--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -348,7 +348,8 @@ class LineChart extends AbstractChart {
                     data: datas,
                     paddingTop,
                     paddingRight,
-                    formatYLabel
+                    formatYLabel,
+                    decimalPlaces: this.props.chartConfig.decimalPlaces
                   })
                 : null}
             </G>


### PR DESCRIPTION
This fixes LineChart so that setting `chartConfig.decimalPlaces` properly acknowledges the override value (defaulted to `2`)

```jsx
<LineChart
  chartConfig={{
    decimalPlaces: 1
  }}
/>
```

![image](https://user-images.githubusercontent.com/1163766/72392049-a5373400-36f4-11ea-8eb6-c490f2a5ed01.png)
