### PR TITLE
fix: Remove .babelrc from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules/
 .expo/
 npm-debug.*
 /promo
+.babelrc


### PR DESCRIPTION
It is causing errors with `eslint-import-resolver-babel-module` not being able to find module `'babel-preset-expo'` is non-expo projects.