### PR TITLE
make decimalPlaces work for StackedBar Chart

### DIFF
--- a/src/stackedbar-chart.js
+++ b/src/stackedbar-chart.js
@@ -109,7 +109,8 @@ class StackedBarChart extends AbstractChart {
       data,
       withHorizontalLabels = true,
       withVerticalLabels = true,
-      segments = 4
+      segments = 4,
+      decimalPlaces
     } = this.props;
     const { borderRadius = 0 } = style;
     const config = {
@@ -151,7 +152,8 @@ class StackedBarChart extends AbstractChart {
                   count: segments,
                   data: [0, border],
                   paddingTop,
-                  paddingRight
+                  paddingRight,
+                  decimalPlaces
                 })
               : null}
           </G>


### PR DESCRIPTION
I was trying to fixed my numbers to 0 decimals I tried alot until I decided to see why it not work from the source code, so I found that the decimalPlaces didn't destructed from the props and not passed to the horizontal labels, so I fixed it by destructing and pass it as a prop to horizontal labels.