### PR TITLE
Added getMonthLabel to ContributionGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,10 @@ const data = {
 const data = {
   labels: ["Test1", "Test2"],
   legend: ["L1", "L2", "L3"],
-  data: [[60, 60, 60], [30, 30, 60]],
+  data: [
+    [60, 60, 60],
+    [30, 30, 60]
+  ],
   barColors: ["#dfe4ea", "#ced6e0", "#a4b0be"]
 };
 ```
@@ -402,13 +405,14 @@ const commitsData = [
 />
 ```
 
-| Property    | Type   | Description                                                                                 |
-| ----------- | ------ | ------------------------------------------------------------------------------------------- |
-| data        | Object | Data for the chart - see example above                                                      |
-| width       | Number | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
-| height      | Number | Height of the chart                                                                         |
-| chartConfig | Object | Configuration object for the chart, see example config in the beginning of this file        |
-| accessor    | string | Property in the `data` object from which the number values are taken                        |
+| Property      | Type     | Description                                                                                 |
+| ------------- | -------- | ------------------------------------------------------------------------------------------- |
+| data          | Object   | Data for the chart - see example above                                                      |
+| width         | Number   | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
+| height        | Number   | Height of the chart                                                                         |
+| chartConfig   | Object   | Configuration object for the chart, see example config in the beginning of this file        |
+| accessor      | string   | Property in the `data` object from which the number values are taken                        |
+| getMonthLabel | function | Function which returns the label for each month, taking month index (0 - 11) as argument    |
 
 ## More styling
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -290,6 +290,7 @@ export interface ContributionGraphProps {
   height: number;
   chartConfig: ChartConfig;
   accessor?: string;
+  getMonthLabel?: (monthIndex: number) => string;
 }
 
 export class ContributionGraph extends React.Component<

--- a/src/contribution-graph/index.js
+++ b/src/contribution-graph/index.js
@@ -265,7 +265,9 @@ class ContributionGraph extends AbstractChart {
           y={y + 8}
           {...this.getPropsForLabels()}
         >
-          {MONTH_LABELS[endOfWeek.getMonth()]}
+          {this.props.getMonthLabel
+            ? this.props.getMonthLabel(endOfWeek.getMonth())
+            : MONTH_LABELS[endOfWeek.getMonth()]}
         </Text>
       ) : null;
     });
@@ -326,7 +328,8 @@ ContributionGraph.ViewPropTypes = {
   tooltipDataAttrs: PropTypes.oneOfType([PropTypes.object, PropTypes.func]), // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
   titleForValue: PropTypes.func, // function which returns title text for value
   classForValue: PropTypes.func, // function which returns html class for value
-  onClick: PropTypes.func // callback function when a square is clicked
+  onClick: PropTypes.func, // callback function when a square is clicked
+  getMonthLabel: PropTypes.func // function which returns label text for month
 };
 
 ContributionGraph.defaultProps = {


### PR DESCRIPTION
This is in response to issue #250 to allow for a custom function (`getMonthLabel`) to be passed as a property to the ContributionGraph component that renders a custom label for each month; if the function is not provided, the "old" `MONTH_LABELS` constant from the project is used by default