### PR TITLE
Added a withDots property to each dataset in LineChart to disable dots on these lines

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,9 @@ export interface Dataset {
   color?: (opacity: number) => string;
   /** The width of the stroke. Defaults to 2. */
   strokeWidth?: number;
+
+  /** A boolean indicating whether to render dots for this line */
+  withDots?: boolean;
 }
 
 export interface ChartData {

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -51,7 +51,10 @@ class LineChart extends AbstractChart {
         return null;
       }
     } = this.props;
+
     data.forEach(dataset => {
+      if (dataset.withDots == false) return;
+
       dataset.data.forEach((x, i) => {
         if (hidePointsAtIndex.includes(i)) {
           return;


### PR DESCRIPTION
Added a `withDots` property to each dataset in LineChart to disable dots on these lines. This is helpful when someone wants to draw reference (boundary) lines on the chart - then, no dots are needed on these lines, but are needed on the main line visualising data, which makes it impossible to use the "global" `withDots` prop on the component.
*Example below*
![image](https://user-images.githubusercontent.com/10586109/75079089-d4b53980-5507-11ea-91cd-2ab39ae0c87f.png)
