### PR TITLE
Fix bug of barchart configuration about barRadius, formatYLabel & formatXLabel

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -82,6 +82,8 @@ class BarChart extends AbstractChart {
       verticalLabelRotation,
       horizontalLabelRotation,
       barRadius: (this.props.chartConfig && this.props.chartConfig.barRadius) || 0,
+      formatYLabel: (this.props.chartConfig && this.props.chartConfig.formatYLabel) || function(label){return label},
+      formatXLabel: (this.props.chartConfig && this.props.chartConfig.formatXLabel) || function(label){return label},
     };
     return (
       <View style={style}>

--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -81,7 +81,7 @@ class BarChart extends AbstractChart {
       height,
       verticalLabelRotation,
       horizontalLabelRotation,
-      barRadius: this.props.chartConfig.barRadius || 0
+      barRadius: (this.props.chartConfig && this.props.chartConfig.barRadius) || 0,
     };
     return (
       <View style={style}>


### PR DESCRIPTION
Fix  bugs below:

1. barRadius bug: Exception of `Cannot read property 'barRadius' of undefined` will be thrown if chartConfig not provided.
2. formatLabels bug: They didn't work.