### PR TITLE
ContributionGraph cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,15 +404,20 @@ const commitsData = [
 />
 ```
 
-| Property      | Type     | Description                                                                                 |
-| ------------- | -------- | ------------------------------------------------------------------------------------------- |
-| data          | Object   | Data for the chart - see example above                                                      |
-| width         | Number   | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
-| height        | Number   | Height of the chart                                                                         |
-| chartConfig   | Object   | Configuration object for the chart, see example config in the beginning of this file        |
-| accessor      | string   | Property in the `data` object from which the number values are taken                        |
-| getMonthLabel | function | Function which returns the label for each month, taking month index (0 - 11) as argument    |
-| onDayPress    | function | Callback invoked when the user clicks a day square on the chart; takes a value-item object  |
+| Property           | Type     | Description                                                                                 |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------- |
+| data               | Object   | Data for the chart - see example above                                                      |
+| width              | Number   | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
+| height             | Number   | Height of the chart                                                                         |
+| gutterSize         | Number   | Size of the gutters between the squares in the chart                                        |
+| squareSize         | Number   | Size of the squares in the chart                                                            |
+| horizontal         | boolean  | Should graph be laid out horizontally? Defaults to `true`                                   |
+| showMonthLabels    | boolean  | Should graph include labels for the months? Defaults to `true`                              |
+| showOutOfRangeDays | boolean  | Should graph be filled with squares, including days outside the range? Defaults to `false`  |
+| chartConfig        | Object   | Configuration object for the chart, see example config in the beginning of this file        |
+| accessor           | string   | Property in the `data` object from which the number values are taken; defaults to `count`   |
+| getMonthLabel      | function | Function which returns the label for each month, taking month index (0 - 11) as argument    |
+| onDayPress         | function | Callback invoked when the user clicks a day square on the chart; takes a value-item object  |
 
 ## More styling
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -295,11 +295,11 @@ export interface ContributionGraphProps {
   numDays: number;
   width: number;
   height: number;
-  gutterSize: number;
-  squareSize: number;
-  horizontal: boolean;
-  showMonthLabels: boolean;
-  showOutOfRangeDays: boolean;
+  gutterSize?: number;
+  squareSize?: number;
+  horizontal?: boolean;
+  showMonthLabels?: boolean;
+  showOutOfRangeDays?: boolean;
   chartConfig: ChartConfig;
   accessor?: string;
   getMonthLabel?: (monthIndex: number) => string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -295,6 +295,11 @@ export interface ContributionGraphProps {
   numDays: number;
   width: number;
   height: number;
+  gutterSize: number;
+  squareSize: number;
+  horizontal: boolean;
+  showMonthLabels: boolean;
+  showOutOfRangeDays: boolean;
   chartConfig: ChartConfig;
   accessor?: string;
   getMonthLabel?: (monthIndex: number) => string;

--- a/src/contribution-graph/index.js
+++ b/src/contribution-graph/index.js
@@ -118,8 +118,8 @@ class ContributionGraph extends AbstractChart {
           (date - this.getStartDateWithEmptyDays()) / MILLISECONDS_IN_ONE_DAY
         );
 
-        minValue = Math.min(value.count, minValue);
-        maxValue = Math.max(value.count, maxValue);
+        minValue = Math.min(value[this.props.accessor], minValue);
+        maxValue = Math.max(value[this.props.accessor], maxValue);
 
         memo[index] = {
           value,
@@ -145,7 +145,7 @@ class ContributionGraph extends AbstractChart {
   getClassNameForIndex(index) {
     if (this.state.valueCache[index]) {
       if (this.state.valueCache[index].value) {
-        const count = this.state.valueCache[index].value.count;
+        const count = this.state.valueCache[index].value[this.props.accessor];
 
         if (count) {
           const opacity = mapValue(
@@ -175,7 +175,7 @@ class ContributionGraph extends AbstractChart {
     if (this.state.valueCache[index]) {
       return this.state.valueCache[index].tooltipDataAttrs;
     }
-    return this.getTooltipDataAttrsForValue({ date: null, count: null });
+    return this.getTooltipDataAttrsForValue({ date: null, [this.props.accessor]: null });
   }
 
   getTooltipDataAttrsForValue(value) {
@@ -273,7 +273,7 @@ class ContributionGraph extends AbstractChart {
       this.state.valueCache[index] && this.state.valueCache[index].value
         ? this.state.valueCache[index].value
         : {
-            count: 0,
+            [this.props.accessor]: 0,
             date: new Date(
               this.getStartDate().valueOf() + index * MILLISECONDS_IN_ONE_DAY
             )
@@ -362,6 +362,7 @@ ContributionGraph.defaultProps = {
   horizontal: true,
   showMonthLabels: true,
   showOutOfRangeDays: false,
+  accessor: "count",
   classForValue: value => (value ? "black" : "#8cc665")
 };
 

--- a/src/contribution-graph/index.js
+++ b/src/contribution-graph/index.js
@@ -35,7 +35,7 @@ class ContributionGraph extends AbstractChart {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let { maxValue, minValue, valueCache } = this.getValueCache(
       nextProps.values
     );


### PR DESCRIPTION
- Adds missing ContributionGraph props to type definitions
- Adds missing ContributionGraph props to README documentation
- Implements missing ContributionGraph `accessor` prop logic
- Renames deprecated method `UNSAFE_componentWillReceiveProps` to avoid warnings until a more permanent approach is ready (`getDerivedStateFromProps` or a conversion to hooks) #254 