### PR TITLE
Bar chart decimal places

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -81,9 +81,18 @@ class BarChart extends AbstractChart {
       height,
       verticalLabelRotation,
       horizontalLabelRotation,
-      barRadius: (this.props.chartConfig && this.props.chartConfig.barRadius) || 0,
-      formatYLabel: (this.props.chartConfig && this.props.chartConfig.formatYLabel) || function(label){return label},
-      formatXLabel: (this.props.chartConfig && this.props.chartConfig.formatXLabel) || function(label){return label},
+      barRadius:
+        (this.props.chartConfig && this.props.chartConfig.barRadius) || 0,
+      formatYLabel:
+        (this.props.chartConfig && this.props.chartConfig.formatYLabel) ||
+        function(label) {
+          return label;
+        },
+      formatXLabel:
+        (this.props.chartConfig && this.props.chartConfig.formatXLabel) ||
+        function(label) {
+          return label;
+        }
     };
     return (
       <View style={style}>
@@ -115,7 +124,8 @@ class BarChart extends AbstractChart {
                   count: segments,
                   data: data.datasets[0].data,
                   paddingTop,
-                  paddingRight
+                  paddingRight,
+                  decimalPlaces: this.props.chartConfig.decimalPlaces
                 })
               : null}
           </G>
@@ -139,12 +149,13 @@ class BarChart extends AbstractChart {
             })}
           </G>
           <G>
-            {showBarTops && this.renderBarTops({
-              ...config,
-              data: data.datasets[0].data,
-              paddingTop,
-              paddingRight
-            })}
+            {showBarTops &&
+              this.renderBarTops({
+                ...config,
+                data: data.datasets[0].data,
+                paddingTop,
+                paddingRight
+              })}
           </G>
         </Svg>
       </View>


### PR DESCRIPTION
Added prop to `BarChart` to be able to set decimal places like in `LineChart`.

New props for BarChart:

- `decimalPlaces`