### PR TITLE
Fixed decimalPlaces not being sent with barChart

### DIFF
--- a/src/bar-chart.js
+++ b/src/bar-chart.js
@@ -82,6 +82,7 @@ class BarChart extends AbstractChart {
       verticalLabelRotation,
       horizontalLabelRotation,
       barRadius: (this.props.chartConfig && this.props.chartConfig.barRadius) || 0,
+      decimalPlaces: (this.props.chartConfig && this.props.chartConfig.decimalPlaces) || 2
       formatYLabel: (this.props.chartConfig && this.props.chartConfig.formatYLabel) || function(label){return label},
       formatXLabel: (this.props.chartConfig && this.props.chartConfig.formatXLabel) || function(label){return label},
     };


### PR DESCRIPTION
The decimalPlaces was being ignored in the config for bar charts because it was not being sent with renderVerticalLabels.