### PR TITLE
Add useShadowColorFromDataset param to the chartConfig

### DIFF
--- a/App.js
+++ b/App.js
@@ -209,6 +209,21 @@ export default class App extends React.Component {
                 style={graphStyle}
                 hidePointsAtIndex={[0, data.datasets[0].data.length - 1]}
               />
+              <Text style={labelStyle}>Line Chart with shadow background as line color</Text>
+              <LineChart
+                bezier
+                data={data}
+                width={width}
+                height={height}
+                yAxisLabel="$"
+                segments={5}
+                chartConfig={{
+                  ...chartConfig,
+                  useShadowColorFromDataset: true
+                }}
+                style={graphStyle}
+                hidePointsAtIndex={[0, data.datasets[0].data.length - 1]}
+              />
 
               <Text style={labelStyle}>Scrollable Line Chart</Text>
               <LineChart

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ const chartConfig = {
   backgroundGradientToOpacity: 0.5,
   color: (opacity = 1) => `rgba(26, 255, 146, ${opacity})`,
   strokeWidth: 2, // optional, default 3
-  barPercentage: 0.5
+  barPercentage: 0.5,
+  useShadowColorFromDataset: false // optional
 };
 ```
 
@@ -98,6 +99,7 @@ const chartConfig = {
 | backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
 | fillShadowGradient            | string             | Defines the color of the area under data                                                               |
 | fillShadowGradientOpacity     | Number             | Defines the initial opacity of the area under data                                                     |
+| useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                               |
 | color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
 | strokeWidth                   | Number             | Defines the base stroke width in a chart                                                               |
 | barPercentage                 | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,6 +350,10 @@ export interface ChartConfig {
   fillShadowGradient?: string;
   fillShadowGradientOpacity?: number;
   /**
+   * Defines the option to use color from dataset to each chart data
+   */
+  useShadowColorFromDataset?: boolean;
+  /**
    * Defines the base color function that is used to calculate colors of labels and sectors used in a chart
    */
   color?: (opacity: number, index?: number) => string;

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -242,7 +242,9 @@ class AbstractChart extends Component {
       width,
       height,
       backgroundGradientFrom,
-      backgroundGradientTo
+      backgroundGradientTo,
+      useShadowColorFromDataset,
+      data
     } = config;
     const fromOpacity = config.hasOwnProperty("backgroundGradientFromOpacity")
       ? config.backgroundGradientFromOpacity
@@ -281,20 +283,42 @@ class AbstractChart extends Component {
             stopOpacity={toOpacity}
           />
         </LinearGradient>
-        <LinearGradient
-          id="fillShadowGradient"
-          x1={0}
-          y1={0}
-          x2={0}
-          y2={height}
-        >
-          <Stop
-            offset="0"
-            stopColor={fillShadowGradient}
-            stopOpacity={fillShadowGradientOpacity}
-          />
-          <Stop offset="1" stopColor={fillShadowGradient} stopOpacity="0" />
-        </LinearGradient>
+        {
+          useShadowColorFromDataset ? (
+            data.map((dataset, index) => (
+              <LinearGradient
+                id={`fillShadowGradient_${index}`}
+                key={`${index}`}
+                x1={0}
+                y1={0}
+                x2={0}
+                y2={height}
+              >
+                <Stop
+                  offset="0"
+                  stopColor={dataset.color()}
+                  stopOpacity={fillShadowGradientOpacity}
+                />
+                <Stop offset="1" stopColor={dataset.color(fillShadowGradientOpacity)} stopOpacity="0" />
+              </LinearGradient>
+            ))
+          ) : (
+            <LinearGradient
+              id="fillShadowGradient"
+              x1={0}
+              y1={0}
+              x2={0}
+              y2={height}
+            >
+              <Stop
+                offset="0"
+                stopColor={fillShadowGradient}
+                stopOpacity={fillShadowGradientOpacity}
+              />
+              <Stop offset="1" stopColor={fillShadowGradient} stopOpacity="0" />
+            </LinearGradient>
+          )
+        }
       </Defs>
     );
   };

--- a/src/abstract-chart.js
+++ b/src/abstract-chart.js
@@ -296,10 +296,10 @@ class AbstractChart extends Component {
               >
                 <Stop
                   offset="0"
-                  stopColor={dataset.color()}
+                  stopColor={dataset.color ? dataset.color() : fillShadowGradient}
                   stopOpacity={fillShadowGradientOpacity}
                 />
-                <Stop offset="1" stopColor={dataset.color(fillShadowGradientOpacity)} stopOpacity="0" />
+                <Stop offset="1" stopColor={dataset.color ? dataset.color(fillShadowGradientOpacity) : fillShadowGradient} stopOpacity="0" />
               </LinearGradient>
             ))
           ) : (

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -308,7 +308,7 @@ class LineChart extends AbstractChart {
       return this.renderBezierShadow(config);
     }
 
-    const { data, width, height, paddingRight, paddingTop } = config;
+    const { data, width, height, paddingRight, paddingTop, useColorFromDataset } = config;
     const datas = this.getDatas(data);
     const baseHeight = this.calcBaseHeight(datas, height);
     return config.data.map((dataset, index) => {
@@ -332,7 +332,7 @@ class LineChart extends AbstractChart {
                 (dataset.data.length - 1)},${(height / 4) * 3 +
               paddingTop} ${paddingRight},${(height / 4) * 3 + paddingTop}`
           }
-          fill="url(#fillShadowGradient)"
+          fill={`url(#fillShadowGradient${useColorFromDataset ? `_${index}` : ''})`}
           strokeWidth={0}
         />
       );
@@ -428,7 +428,7 @@ class LineChart extends AbstractChart {
   };
 
   renderBezierShadow = config => {
-    const { width, height, paddingRight, paddingTop, data } = config;
+    const { width, height, paddingRight, paddingTop, data, useColorFromDataset } = config;
     return data.map((dataset, index) => {
       const d =
         this.getBezierLinePoints(dataset, config) +
@@ -440,7 +440,7 @@ class LineChart extends AbstractChart {
         <Path
           key={index}
           d={d}
-          fill="url(#fillShadowGradient)"
+          fill={`url(#fillShadowGradient${useColorFromDataset ? `_${index}` : ''})`}
           strokeWidth={0}
         />
       );
@@ -485,7 +485,8 @@ class LineChart extends AbstractChart {
       formatYLabel = yLabel => yLabel,
       formatXLabel = xLabel => xLabel,
       segments,
-      transparent = false
+      transparent = false,
+      chartConfig = {},
     } = this.props;
     const { scrollableDotHorizontalOffset } = this.state;
     const { labels = [] } = data;
@@ -533,7 +534,8 @@ class LineChart extends AbstractChart {
           <G x="0" y={legendOffset}>
             {this.renderDefs({
               ...config,
-              ...this.props.chartConfig
+              ...chartConfig,
+              data: data.datasets
             })}
             <G>
               {withInnerLines
@@ -560,7 +562,7 @@ class LineChart extends AbstractChart {
                     paddingTop,
                     paddingRight,
                     formatYLabel,
-                    decimalPlaces: this.props.chartConfig.decimalPlaces
+                    decimalPlaces: chartConfig.decimalPlaces
                   })
                 : null}
             </G>
@@ -594,7 +596,7 @@ class LineChart extends AbstractChart {
             <G>
               {this.renderLine({
                 ...config,
-                ...this.props.chartConfig,
+                ...chartConfig,
                 paddingRight,
                 paddingTop,
                 data: data.datasets
@@ -606,7 +608,8 @@ class LineChart extends AbstractChart {
                   ...config,
                   data: data.datasets,
                   paddingRight,
-                  paddingTop
+                  paddingTop,
+                  useColorFromDataset: chartConfig.useShadowColorFromDataset,
                 })}
             </G>
             <G>
@@ -623,7 +626,7 @@ class LineChart extends AbstractChart {
               {withScrollableDot &&
                 this.renderScrollableDot({
                   ...config,
-                  ...this.props.chartConfig,
+                  ...chartConfig,
                   data: data.datasets,
                   paddingTop,
                   paddingRight,


### PR DESCRIPTION
For now in the **Line chart** if we have more than one data in the dataset the shadow use only one color from `fillShadowGradient` params. I propose to use `useShadowColorFromDataset` param to select draw color from `fillShadowGradient` or use color from each line.