### PR TITLE
Added decorator for scrollable dot info text

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -422,6 +422,11 @@ export interface ChartConfig {
   scrollableInfoTextStyle?: TextStyle;
 
   /**
+   * Define decorator function for scrollable dot text
+   */
+  scrollableInfoTextDecorator?: (text: string) => string
+
+  /**
    * Set Info View offset
    */
   scrollableInfoOffset?: number;

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -135,7 +135,7 @@ class LineChart extends AbstractChart {
       scrollableDotRadius,
       scrollableInfoViewStyle,
       scrollableInfoTextStyle,
-      scrollableInfoTextDecorator = (text => text),
+      scrollableInfoTextDecorator = (text => `${text}`),
       scrollableInfoSize,
       scrollableInfoOffset
     } = config;

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -135,6 +135,7 @@ class LineChart extends AbstractChart {
       scrollableDotRadius,
       scrollableInfoViewStyle,
       scrollableInfoTextStyle,
+      scrollableInfoTextDecorator =  (text => text),
       scrollableInfoSize,
       scrollableInfoOffset
     } = config;
@@ -162,7 +163,7 @@ class LineChart extends AbstractChart {
 
       if (index >= data[0].data.length - 1) {
         this.label.current.setNativeProps({
-          text: `${Math.floor(data[0].data[0])}`
+          text: scrollableInfoTextDecorator(Math.floor(data[0].data[0]))
         });
       } else {
         if (index > lastIndex) {
@@ -173,12 +174,12 @@ class LineChart extends AbstractChart {
           if (prev > base) {
             let rest = prev - base;
             this.label.current.setNativeProps({
-              text: `${Math.floor(base + percent * rest)}`
+              text: scrollableInfoTextDecorator(Math.floor(base + percent * rest))
             });
           } else {
             let rest = base - prev;
             this.label.current.setNativeProps({
-              text: `${Math.floor(base - percent * rest)}`
+              text: scrollableInfoTextDecorator(Math.floor(base - percent * rest))
             });
           }
         } else {
@@ -190,12 +191,12 @@ class LineChart extends AbstractChart {
           if (next > base) {
             let rest = next - base;
             this.label.current.setNativeProps({
-              text: `${Math.floor(base + percent * rest)}`
+              text: scrollableInfoTextDecorator(Math.floor(base + percent * rest))
             });
           } else {
             let rest = base - next;
             this.label.current.setNativeProps({
-              text: `${Math.floor(base - percent * rest)}`
+              text: scrollableInfoTextDecorator(Math.floor(base - percent * rest))
             });
           }
         }
@@ -281,7 +282,7 @@ class LineChart extends AbstractChart {
           <TextInput
             onLayout={() => {
               this.label.current.setNativeProps({
-                text: `${Math.floor(data[0].data[data[0].data.length - 1])}`
+                text: scrollableInfoTextDecorator(Math.floor(data[0].data[data[0].data.length - 1]))
               });
             }}
             style={scrollableInfoTextStyle}

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -135,7 +135,7 @@ class LineChart extends AbstractChart {
       scrollableDotRadius,
       scrollableInfoViewStyle,
       scrollableInfoTextStyle,
-      scrollableInfoTextDecorator =  (text => text),
+      scrollableInfoTextDecorator = (text => text),
       scrollableInfoSize,
       scrollableInfoOffset
     } = config;


### PR DESCRIPTION
I need the option to decorate (transform numbers, append strings) the text shown in the scrollable dot info view so I added a decorator function for that text.

The decorator is optional, when not provided it falls back to the original implementation with a function returning the original text.

Example:

No decorator function provided:
<img width="326" alt="Screen Shot 2020-06-16 at 20 09 18" src="https://user-images.githubusercontent.com/9248169/84805708-5bd57280-b00d-11ea-993f-1439da2e28ed.png">

Decorator function provided:
```
const chartConfig = {
    ...
    scrollableInfoTextDecorator: (text) => `${Number(text).toLocaleString()} ${CURRENCY_CODE}`,
}
```

<img width="328" alt="Screen Shot 2020-06-16 at 20 09 45" src="https://user-images.githubusercontent.com/9248169/84805716-5d069f80-b00d-11ea-842a-ce7c6ef3b0db.png">