### PR TITLE
Updated Line Chart Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ const data = {
       strokeWidth: 2 // optional
     }
   ],
-  legend: ["Rainy Days", "Sunny Days", "Snowy Days"] // optional
+  legend: ["Rainy Days"] // optional
 };
 ```
 


### PR DESCRIPTION
I updated the Line Chart example's data from having three elements in the legend array to one to match the datasets array length.  This was causing dataset.color in line-chart to resolve to undefined because of legend.map in renderLegend.

There was thread in your issue tracker that seems to have began because of this.
https://github.com/indiespirit/react-native-chart-kit/issues/245