### PR TITLE
Bezier line bugfix

### DIFF
--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -595,7 +595,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop" | "linejoinType"
   >) => {
-    if (!this.props.bezier) {
+    if (this.props.bezier) {
       return this.renderBezierLine({
         data,
         width,


### PR DESCRIPTION
For some reason the logic was reversed in the renderLine function, and it would return a bezier line if props.bezier was not true.