### PR TITLE
Fix: move withVerticalLines and withHorizontalLines props to correct section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ const data = {
 | data                    | Object          | Data for the chart - see example above                                                      |
 | width                   | Number          | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
 | height                  | Number          | Height of the chart                                                                         |
-| withVerticalLabels      | boolean         | Show vertical lines - default: True                                                         |
+| withVerticalLines       | boolean         | Show vertical lines - default: True                                                         |
 | withHorizontalLines     | boolean         | Show horizontal lines - default: True                                                       |
-| withVerticalLines       | boolean         | Show vertical labels - default: True                                                        |
+| withVerticalLables      | boolean         | Show vertical labels - default: True                                                        |
 | withHorizontalLabels    | boolean         | Show horizontal labels - default: True                                                      |
 | fromZero                | boolean         | Render charts from 0 not from the minimum value. - default: False                           |
 | withInnerLines          | boolean         | Show inner dashed lines - default: True                                                     |

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ const data = {
 | withShadow              | boolean                 | Show shadow for line - default: True                                                                                                                                                                                           |
 | withInnerLines          | boolean                 | Show inner dashed lines - default: True                                                                                                                                                                                        |
 | withOuterLines          | boolean                 | Show outer dashed lines - default: True                                                                                                                                                                                        |
+| withVerticalLines       | boolean                 | Show vertical lines - default: True                                                                                                                                                                                            |
+| withHorizontalLines     | boolean                 | Show horizontal lines - default: True                                                                                                                                                                                          |
 | withVerticalLabels      | boolean                 | Show vertical labels - default: True                                                                                                                                                                                           |
 | withHorizontalLabels    | boolean                 | Show horizontal labels - default: True                                                                                                                                                                                         |
 | fromZero                | boolean                 | Render charts from 0 not from the minimum value. - default: False                                                                                                                                                              |
@@ -261,8 +263,6 @@ const data = {
 | data                    | Object          | Data for the chart - see example above                                                      |
 | width                   | Number          | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
 | height                  | Number          | Height of the chart                                                                         |
-| withVerticalLines       | boolean         | Show vertical lines - default: True                                                         |
-| withHorizontalLines     | boolean         | Show horizontal lines - default: True                                                       |
 | withVerticalLables      | boolean         | Show vertical labels - default: True                                                        |
 | withHorizontalLabels    | boolean         | Show horizontal labels - default: True                                                      |
 | fromZero                | boolean         | Render charts from 0 not from the minimum value. - default: False                           |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ const data = {
 | data                    | Object          | Data for the chart - see example above                                                      |
 | width                   | Number          | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
 | height                  | Number          | Height of the chart                                                                         |
-| withVerticalLabels      | boolean         | Show vertical labels - default: True                                                        |
+| withVerticalLabels      | boolean         | Show vertical lines - default: True                                                         |
+| withHorizontalLines     | boolean         | Show horizontal lines - default: True                                                       |
+| withVerticalLines       | boolean         | Show vertical labels - default: True                                                        |
 | withHorizontalLabels    | boolean         | Show horizontal labels - default: True                                                      |
 | fromZero                | boolean         | Render charts from 0 not from the minimum value. - default: False                           |
 | withInnerLines          | boolean         | Show inner dashed lines - default: True                                                     |

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -76,6 +76,14 @@ export interface LineChartProps extends AbstractChartProps {
    */
   withOuterLines?: boolean;
   /**
+   * Show vertical lines - default: True.
+   */
+  withVerticalLines?: boolean;
+  /**
+   * Show horizontal lines - default: True.
+   */
+  withHorizontalLines?: boolean;
+  /**
    * Show vertical labels - default: True.
    */
   withVerticalLabels?: boolean;
@@ -784,6 +792,8 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       withDots = true,
       withInnerLines = true,
       withOuterLines = true,
+      withHorizontalLines = true,
+      withVerticalLines = true,
       withHorizontalLabels = true,
       withVerticalLabels = true,
       style = {},
@@ -848,60 +858,60 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
               data: data.datasets
             })}
             <G>
-              {withInnerLines
-                ? this.renderHorizontalLines({
-                    ...config,
-                    count: count,
-                    paddingTop,
-                    paddingRight
-                  })
-                : withOuterLines
-                ? this.renderHorizontalLine({
-                    ...config,
-                    paddingTop,
-                    paddingRight
-                  })
-                : null}
+              {withHorizontalLines &&
+                (withInnerLines
+                  ? this.renderHorizontalLines({
+                      ...config,
+                      count: count,
+                      paddingTop,
+                      paddingRight
+                    })
+                  : withOuterLines
+                  ? this.renderHorizontalLine({
+                      ...config,
+                      paddingTop,
+                      paddingRight
+                    })
+                  : null)}
             </G>
             <G>
-              {withHorizontalLabels
-                ? this.renderHorizontalLabels({
-                    ...config,
-                    count: count,
-                    data: datas,
-                    paddingTop: paddingTop as number,
-                    paddingRight: paddingRight as number,
-                    formatYLabel,
-                    decimalPlaces: chartConfig.decimalPlaces
-                  })
-                : null}
+              {withHorizontalLabels &&
+                this.renderHorizontalLabels({
+                  ...config,
+                  count: count,
+                  data: datas,
+                  paddingTop: paddingTop as number,
+                  paddingRight: paddingRight as number,
+                  formatYLabel,
+                  decimalPlaces: chartConfig.decimalPlaces
+                })}
             </G>
             <G>
-              {withInnerLines
-                ? this.renderVerticalLines({
-                    ...config,
-                    data: data.datasets[0].data,
-                    paddingTop: paddingTop as number,
-                    paddingRight: paddingRight as number
-                  })
-                : withOuterLines
-                ? this.renderVerticalLine({
-                    ...config,
-                    paddingTop: paddingTop as number,
-                    paddingRight: paddingRight as number
-                  })
-                : null}
+              {withVerticalLines &&
+                (withInnerLines
+                  ? this.renderVerticalLines({
+                      ...config,
+                      data: data.datasets[0].data,
+                      paddingTop: paddingTop as number,
+                      paddingRight: paddingRight as number
+                    })
+                  : withOuterLines
+                  ? this.renderVerticalLine({
+                      ...config,
+                      paddingTop: paddingTop as number,
+                      paddingRight: paddingRight as number
+                    })
+                  : null)}
             </G>
             <G>
-              {withVerticalLabels
-                ? this.renderVerticalLabels({
-                    ...config,
-                    labels,
-                    paddingTop: paddingTop as number,
-                    paddingRight: paddingRight as number,
-                    formatXLabel
-                  })
-                : null}
+              {withVerticalLabels &&
+                this.renderVerticalLabels({
+                  ...config,
+                  labels,
+                  paddingTop: paddingTop as number,
+                  paddingRight: paddingRight as number,
+                  formatXLabel
+                })}
             </G>
             <G>
               {this.renderLine({


### PR DESCRIPTION
Noticed after checking over my last PR that I had them in the BarChart props section of the README rather than the LineChart props section. This PR moves them into the correct section.