### PR TITLE
Issue #373 - Condition added to divide width by 2 for x value...

### DIFF
--- a/src/ProgressChart.tsx
+++ b/src/ProgressChart.tsx
@@ -170,7 +170,7 @@ class ProgressChart extends AbstractChart<
             ry={borderRadius}
             fill="url(#backgroundGradient)"
           />
-          <G x={this.props.width / 2.5} y={this.props.height / 2}>
+          <G x={this.props.width / (hideLegend ? 2 : 2.5)} y={this.props.height / 2}>
             <G>
               {pieBackgrounds.map((pie, i) => {
                 return (


### PR DESCRIPTION
... if legend is hidden

## Divides width by 2 instead of 2.5, when legend is hidden

![image](https://user-images.githubusercontent.com/1063420/87609340-86275800-c6bf-11ea-89d8-65e38b7d8b24.png)