### PR TITLE
fix: typescript types on abstractchart (#368 #363)

### DIFF
--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -16,12 +16,12 @@ export interface AbstractChartProps {
 }
 
 export interface AbstractChartConfig extends ChartConfig {
-  count: number;
-  data: Dataset[];
-  width: number;
-  height: number;
-  paddingTop: number;
-  paddingRight: number;
+  count?: number;
+  data?: Dataset[];
+  width?: number;
+  height?: number;
+  paddingTop?: number;
+  paddingRight?: number;
   horizontalLabelRotation?: number;
   formatYLabel?: (yLabel: string) => string;
   labels?: string[];


### PR DESCRIPTION
Closes #368 and #363 

This makes the types in AbstractChart optional. I ran the app with the changes in expo and didn't see any issues. 

Let me know if there was anything I missed or further testing I need to do.