### PR TITLE
Stacked bar percentile stacking

### DIFF
--- a/App.js
+++ b/App.js
@@ -172,6 +172,15 @@ export default class App extends React.Component {
                 height={220}
                 chartConfig={chartConfig}
               />
+              <Text style={labelStyle}>Stacked Bar Graph Percentile</Text>
+              <StackedBarChart
+                style={graphStyle}
+                data={stackedBarGraphData}
+                width={width}
+                height={220}
+                chartConfig={chartConfig}
+                percentile
+              />
               <Text style={labelStyle}>Pie Chart</Text>
               <PieChart
                 data={pieChartData}

--- a/src/StackedBarChart.tsx
+++ b/src/StackedBarChart.tsx
@@ -48,6 +48,8 @@ export interface StackedBarChartProps extends AbstractChartProps {
    * The number of horizontal lines
    */
   segments?: number;
+
+  percentile?: boolean;
 }
 
 type StackedBarChartState = {};
@@ -94,10 +96,9 @@ class StackedBarChart extends AbstractChart<
       if (stackedBar) {
         fac = 0.7;
       }
-
+      const sum = this.props.percentile ? x.reduce((a, b) => a + b, 0) : border;
       for (let z = 0; z < x.length; z++) {
-        h = (height - 55) * (x[z] / border);
-
+        h = (height - 55) * (x[z] / sum);
         const y = (height / 4) * 3 - h + st;
         const xC =
           (paddingRight +
@@ -182,7 +183,8 @@ class StackedBarChart extends AbstractChart<
       withHorizontalLabels = true,
       withVerticalLabels = true,
       segments = 4,
-      decimalPlaces
+      decimalPlaces,
+      percentile = false
     } = this.props;
 
     const { borderRadius = 0 } = style;
@@ -192,11 +194,19 @@ class StackedBarChart extends AbstractChart<
     };
 
     let border = 0;
+
+    let max = 0;
     for (let i = 0; i < data.data.length; i++) {
       const actual = data.data[i].reduce((pv, cv) => pv + cv, 0);
-      if (actual > border) {
-        border = actual;
+      if (actual > max) {
+        max = actual;
       }
+    }
+
+    if (percentile) {
+      border = 100;
+    } else {
+      border = max;
     }
 
     var stackedBar = data.legend && data.legend.length == 0 ? false : true;


### PR DESCRIPTION
Added option for stacking based on percentage of the value of item instead or normal stacking. Just add property `percentile` to stacked bar chart and it will work as the screenshot below.

![image](https://user-images.githubusercontent.com/24951758/89095791-aeff5b00-d3ea-11ea-8df0-fed81a520d3a.png)


```
 <StackedBarChart
     style={graphStyle}
     data={stackedBarGraphData}
     width={width}
     height={220}
     chartConfig={chartConfig}
     percentile
/>
```