### PR TITLE
Add PieChart props avoidFalseZero

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,17 +373,18 @@ const data = [
 />
 ```
 
-| Property    | Type    | Description                                                                                 |
-| ----------- | ------- | ------------------------------------------------------------------------------------------- |
-| data        | Object  | Data for the chart - see example above                                                      |
-| width       | Number  | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive |
-| height      | Number  | Height of the chart                                                                         |
-| chartConfig | Object  | Configuration object for the chart, see example config in the beginning of this file        |
-| accessor    | string  | Property in the `data` object from which the number values are taken                        |
-| bgColor     | string  | background color - if you want to set transparent, input `transparent` or `none`.           |
-| paddingLeft | string  | left padding of the pie chart                                                               |
-| absolute    | boolean | shows the values as absolute numbers                                                        |
-| hasLegend   | boolean | Defaults to `true`, set it to `false` to remove the legend                                  |
+| Property       | Type     | Description                                                                                        |
+| -------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| data           | Object   | Data for the chart - see example above                                                             |
+| width          | Number   | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive        |
+| height         | Number   | Height of the chart                                                                                |
+| chartConfig    | Object   | Configuration object for the chart, see example config in the beginning of this file               |
+| accessor       | string   | Property in the `data` object from which the number values are taken                               |
+| bgColor        | string   | background color - if you want to set transparent, input `transparent` or `none`.                  |
+| paddingLeft    | string   | left padding of the pie chart                                                                      |
+| absolute       | boolean  | shows the values as absolute numbers                                                               |
+| hasLegend      | boolean  | Defaults to `true`, set it to `false` to remove the legend                                         |
+| avoidFalseZero |  boolean |  Defaults to `false`, set it to `true` to display a ">1%" instead of a rounded value equal to "0%" |
 
 ## Contribution graph (heatmap)
 

--- a/README.md
+++ b/README.md
@@ -373,18 +373,18 @@ const data = [
 />
 ```
 
-| Property       | Type     | Description                                                                                        |
-| -------------- | -------- | -------------------------------------------------------------------------------------------------- |
-| data           | Object   | Data for the chart - see example above                                                             |
-| width          | Number   | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive        |
-| height         | Number   | Height of the chart                                                                                |
-| chartConfig    | Object   | Configuration object for the chart, see example config in the beginning of this file               |
-| accessor       | string   | Property in the `data` object from which the number values are taken                               |
-| bgColor        | string   | background color - if you want to set transparent, input `transparent` or `none`.                  |
-| paddingLeft    | string   | left padding of the pie chart                                                                      |
-| absolute       | boolean  | shows the values as absolute numbers                                                               |
-| hasLegend      | boolean  | Defaults to `true`, set it to `false` to remove the legend                                         |
-| avoidFalseZero |  boolean |  Defaults to `false`, set it to `true` to display a ">1%" instead of a rounded value equal to "0%" |
+| Property       | Type    | Description                                                                                       |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| data           | Object  | Data for the chart - see example above                                                            |
+| width          | Number  | Width of the chart, use 'Dimensions' library to get the width of your screen for responsive       |
+| height         | Number  | Height of the chart                                                                               |
+| chartConfig    | Object  | Configuration object for the chart, see example config in the beginning of this file              |
+| accessor       | string  | Property in the `data` object from which the number values are taken                              |
+| bgColor        | string  | background color - if you want to set transparent, input `transparent` or `none`.                 |
+| paddingLeft    | string  | left padding of the pie chart                                                                     |
+| absolute       | boolean | shows the values as absolute numbers                                                              |
+| hasLegend      | boolean | Defaults to `true`, set it to `false` to remove the legend                                        |
+| avoidFalseZero | boolean | Defaults to `false`, set it to `true` to display a "<1%" instead of a rounded value equal to "0%" |
 
 ## Contribution graph (heatmap)
 

--- a/src/PieChart.tsx
+++ b/src/PieChart.tsx
@@ -16,6 +16,7 @@ export interface PieChartProps extends AbstractChartProps {
   absolute?: boolean;
   hasLegend?: boolean;
   style?: Partial<ViewStyle>;
+  avoidFalseZero?: boolean;
 }
 
 type PieChartState = {};
@@ -26,7 +27,8 @@ class PieChart extends AbstractChart<PieChartProps, PieChartState> {
       style = {},
       backgroundColor,
       absolute = false,
-      hasLegend = true
+      hasLegend = true,
+      avoidFalseZero = false
     } = this.props;
 
     const { borderRadius = 0 } = style;
@@ -54,7 +56,15 @@ class PieChart extends AbstractChart<PieChartProps, PieChartState> {
         if (total === 0) {
           value = 0 + "%";
         } else {
+          const percentage = Math.round(
+            (100 / total) * c.item[this.props.accessor]
+          );
           value = Math.round((100 / total) * c.item[this.props.accessor]) + "%";
+          if (avoidFalseZero && percentage === 0) {
+            value = ">1%";
+          } else {
+            value = percentage + "%";
+          }
         }
       }
 

--- a/src/PieChart.tsx
+++ b/src/PieChart.tsx
@@ -61,7 +61,7 @@ class PieChart extends AbstractChart<PieChartProps, PieChartState> {
           );
           value = Math.round((100 / total) * c.item[this.props.accessor]) + "%";
           if (avoidFalseZero && percentage === 0) {
-            value = ">1%";
+            value = "<1%";
           } else {
             value = percentage + "%";
           }


### PR DESCRIPTION
When one or some of the data given to a PieChart is displayed as `0%` even though the data are not equal to zero, you might want to instead display a `>1%` to better represent the value.

* Add an optional `avoidFalseZero` props to PieChart. Defaults value is `false`
* Update the README accordingly