### PR TITLE
Added support for providing styles for labels separately

### DIFF
--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -97,6 +97,30 @@ class AbstractChart<
     };
   }
 
+  getPropsForVerticalLabels() {
+    const {
+      propsForVerticalLabels = {},
+      color,
+      labelColor = color
+    } = this.props.chartConfig;
+    return {
+      fill: labelColor(0.8),
+      ...propsForVerticalLabels
+    };
+  }
+
+  getPropsForHorizontalLabels() {
+    const {
+      propsForHorizontalLabels = {},
+      color,
+      labelColor = color
+    } = this.props.chartConfig;
+    return {
+      fill: labelColor(0.8),
+      ...propsForHorizontalLabels
+    };
+  }
+
   renderHorizontalLines = config => {
     const { count, width, height, paddingTop, paddingRight } = config;
     const basePosition = height - height / 4;
@@ -180,6 +204,7 @@ class AbstractChart<
           textAnchor="end"
           y={y}
           {...this.getPropsForLabels()}
+          {...this.getPropsForHorizontalLabels()}
         >
           {yLabel}
         </Text>
@@ -244,6 +269,7 @@ class AbstractChart<
           y={y}
           textAnchor={verticalLabelRotation === 0 ? "middle" : "start"}
           {...this.getPropsForLabels()}
+          {...this.getPropsForVerticalLabels()}
         >
           {`${formatXLabel(label)}${xAxisLabel}`}
         </Text>

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -74,6 +74,15 @@ export interface ChartConfig {
    */
   propsForLabels?: TextProps;
   /**
+   * Override styles of vertical labels, refer to react-native-svg's Text documentation
+   */
+  propsForVerticalLabels?: TextProps;
+
+  /**
+   * Override styles of horizontal labels, refer to react-native-svg's Text documentation
+   */
+  propsForHorizontalLabels?: TextProps;
+  /**
    * Override styles of the dots, refer to react-native-svg's Text documentation
    */
   propsForDots?: CircleProps;


### PR DESCRIPTION
Now you can pass props for labels separately for vertical and horizontal labels.

`propsForVerticalLabels` & `propsForHorizontalLabels`