### PR TITLE
Improve shadow gradient

### DIFF
--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -417,11 +417,7 @@ class AbstractChart<
               />
               <Stop
                 offset="1"
-                stopColor={
-                  dataset.color
-                    ? dataset.color(fillShadowGradientOpacity)
-                    : fillShadowGradient
-                }
+                stopColor="transparent"
                 stopOpacity="0"
               />
             </LinearGradient>
@@ -440,7 +436,7 @@ class AbstractChart<
               stopColor={fillShadowGradient}
               stopOpacity={fillShadowGradientOpacity}
             />
-            <Stop offset="1" stopColor={fillShadowGradient} stopOpacity="0" />
+            <Stop offset="1" stopColor="transparent" stopOpacity="0" />
           </LinearGradient>
         )}
       </Defs>


### PR DESCRIPTION
Currently the bottom of the shadow gradient doesn't look 100% transparent if you use a fillShadowGradientOpacity of 0.5 or higher.

The change makes it possible to achieve for example the following result:
![Image of Spotify Equalizer](https://community.spotify.com/t5/image/serverpage/image-id/102277i297523D7FCB8B963?v=1.0)