### PR TITLE
Fix to display the correct height bar even if changing the "height" of the props in StackedBar

### DIFF
--- a/src/StackedBarChart.tsx
+++ b/src/StackedBarChart.tsx
@@ -95,9 +95,10 @@ class StackedBarChart extends AbstractChart<
         fac = 0.7;
       }
       const sum = this.props.percentile ? x.reduce((a, b) => a + b, 0) : border;
+      const barsAreaHeight = (height / 4) * 3;
       for (let z = 0; z < x.length; z++) {
-        h = (height - 55) * (x[z] / sum);
-        const y = (height / 4) * 3 - h + st;
+        h = barsAreaHeight * (x[z] / sum);
+        const y = barsAreaHeight - h + st;
         const xC =
           (paddingRight +
             (i * (width - paddingRight)) / data.length +


### PR DESCRIPTION
### Problem
When I changed the prop "height" from 220 to 300, I got wrong bar height in StackedBarGraph like bellow.
<img src="https://user-images.githubusercontent.com/24880178/96989980-7098b880-1561-11eb-85ed-97c85ce5c731.png" width="300">

### The reason that the problem occurred
Because it used a fixed value that is valid only at height: 220 to determine the position of y.

### Solution
I changed to calculate y position using height passed by props.

