### PR TITLE
Allow usage of custom color for each bar on BarChart

### DIFF
--- a/src/BarChart.tsx
+++ b/src/BarChart.tsx
@@ -139,7 +139,7 @@ class BarChart extends AbstractChart<BarChartProps, BarChartState> {
     data,
     flatColor
   }: Pick<AbstractChartConfig, "data"> & {
-    flatColor?: boolean;
+    flatColor: boolean;
   }) => {
     return data.map((dataset, index) => (
       <Defs>

--- a/src/BarChart.tsx
+++ b/src/BarChart.tsx
@@ -18,12 +18,8 @@ import { ChartData } from "./HelperTypes";
 
 const barWidth = 32;
 
-export interface BarChartData extends ChartData {
-  colors?: Array<(opacity: number) => string>;
-}
-
 export interface BarChartProps extends AbstractChartProps {
-  data: BarChartData;
+  data: ChartData;
   width: number;
   height: number;
   fromZero?: boolean;
@@ -49,6 +45,7 @@ export interface BarChartProps extends AbstractChartProps {
   showBarTops?: boolean;
   showValuesOnTopOfBars?: boolean;
   withCustomBarColorFromData?: boolean;
+  flatColor?: boolean;
 }
 
 type BarChartState = {};
@@ -138,26 +135,38 @@ class BarChart extends AbstractChart<BarChartProps, BarChartState> {
     });
   };
 
-  renderColors = ({ data }: Pick<AbstractChartConfig, "data">) => {
-    return data.map((dataset, index) => {
-      return (
-        <Defs>
-          {dataset.colors.map((color, colorIndex) => (
+  renderColors = ({
+    data,
+    flatColor
+  }: Pick<AbstractChartConfig, "data"> & {
+    flatColor?: boolean;
+  }) => {
+    return data.map((dataset, index) => (
+      <Defs>
+        {dataset.colors?.map((color, colorIndex) => {
+          const highOpacityColor = color(1.0);
+          const lowOpacityColor = color(0.1);
+
+          return (
             <LinearGradient
               id={`customColor_${index}_${colorIndex}`}
-              key={`${index}`}
+              key={`${index}_${colorIndex}`}
               x1={0}
               y1={0}
               x2={0}
               y2={1}
             >
-              <Stop offset="0" stopColor={color(1.0)} stopOpacity="1" />
-              <Stop offset="1" stopColor={color(0.1)} stopOpacity="0" />
+              <Stop offset="0" stopColor={highOpacityColor} stopOpacity="1" />
+              {flatColor ? (
+                <Stop offset="1" stopColor={highOpacityColor} stopOpacity="1" />
+              ) : (
+                <Stop offset="1" stopColor={lowOpacityColor} stopOpacity="0" />
+              )}
             </LinearGradient>
-          ))}
-        </Defs>
-      );
-    });
+          );
+        })}
+      </Defs>
+    ));
   };
 
   renderValuesOnTopOfBars = ({
@@ -210,6 +219,7 @@ class BarChart extends AbstractChart<BarChartProps, BarChartState> {
       showBarTops = true,
       withCustomBarColorFromData = false,
       showValuesOnTopOfBars = false,
+      flatColor = false,
       segments = 4
     } = this.props;
 
@@ -244,7 +254,8 @@ class BarChart extends AbstractChart<BarChartProps, BarChartState> {
             ...this.props.chartConfig
           })}
           {this.renderColors({
-            ...this.props.chartConfig
+            ...this.props.chartConfig,
+            flatColor: flatColor
           })}
           <Rect
             width="100%"

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -8,6 +8,9 @@ export interface Dataset {
   /** A function returning the color of the stroke given an input opacity value. */
   color?: (opacity: number) => string;
 
+  /** A function returning array of the colors of the stroke given an input opacity value for each data value. */
+  colors?: Array<(opacity: number) => string>;
+
   /** The width of the stroke. Defaults to 2. */
   strokeWidth?: number;
 


### PR DESCRIPTION
This PR allows user to input a custom color for each bar of a data on BarChart.

Also adds an option so user's can set colors to be flat instead of gradient

Example:
```jsx
// ....
 const dataset = {
    labels: ["january", "february", "may"],
    datasets: [
      {
        data: [100, 500, 300],
        colors: [
          (opacity = 1) => `red`,
          (opacity = 1) => `#ff00ff`,
          (opacity = 1) => `rgba(255, 0, 50, ${opacity})`,
        ]
      }
    ]
  }
// ...
    <BarChart
      data={dataset}
      width={300}
      height={220}
      withCustomBarColorFromData={true}
      flatColor={true}
      chartConfig={{
        backgroundColor: '#ffffff',
        backgroundGradientFrom: '#ffffff',
        backgroundGradientTo: '#ffffff',
        data: dataset.datasets,
        color: (opacity = 1) => '#fff',
        labelColor: () => '#6a6a6a',
      }}
    />
```