### PR TITLE
Allow usage of custom color for each bar on ProgressChart

### DIFF
--- a/src/ProgressChart.tsx
+++ b/src/ProgressChart.tsx
@@ -10,7 +10,7 @@ import AbstractChart, {
 
 export type ProgressChartData =
   | Array<number>
-  | { labels?: Array<string>; data: Array<number> };
+  | { labels?: Array<string>; colors?:Array<string>; data: Array<number>; };
 
 export interface ProgressChartProps extends AbstractChartProps {
   data: ProgressChartData;
@@ -93,6 +93,9 @@ class ProgressChart extends AbstractChart<
 
     const withLabel = (i: number) =>
       (data as any).labels && (data as any).labels[i];
+    
+    const withColor = (i: number) =>
+      (data as any).colors && (data as any).colors[i];
 
     const legend = !hideLegend && (
       <>
@@ -192,10 +195,7 @@ class ProgressChart extends AbstractChart<
                     strokeLinejoin="round"
                     d={pie.curves[0].sector.path.print()}
                     strokeWidth={strokeWidth}
-                    stroke={this.props.chartConfig.color(
-                      (i / pies.length) * 0.5 + 0.5,
-                      i
-                    )}
+                    stroke={withColor(i)}
                   />
                 );
               })}

--- a/src/ProgressChart.tsx
+++ b/src/ProgressChart.tsx
@@ -10,7 +10,7 @@ import AbstractChart, {
 
 export type ProgressChartData =
   | Array<number>
-  | { labels?: Array<string>; colors?:Array<string>; data: Array<number>; };
+  | { labels?: Array<string>; colors?: Array<string>; data: Array<number> };
 
 export interface ProgressChartProps extends AbstractChartProps {
   data: ProgressChartData;
@@ -27,6 +27,7 @@ export interface ProgressChartProps extends AbstractChartProps {
   hideLegend?: boolean;
   strokeWidth?: number;
   radius?: number;
+  withCustomBarColorFromData?: boolean;
 }
 
 type ProgressChartState = {};
@@ -93,7 +94,7 @@ class ProgressChart extends AbstractChart<
 
     const withLabel = (i: number) =>
       (data as any).labels && (data as any).labels[i];
-    
+
     const withColor = (i: number) =>
       (data as any).colors && (data as any).colors[i];
 
@@ -173,7 +174,10 @@ class ProgressChart extends AbstractChart<
             ry={borderRadius}
             fill="url(#backgroundGradient)"
           />
-          <G x={this.props.width / (hideLegend ? 2 : 2.5)} y={this.props.height / 2}>
+          <G
+            x={this.props.width / (hideLegend ? 2 : 2.5)}
+            y={this.props.height / 2}
+          >
             <G>
               {pieBackgrounds.map((pie, i) => {
                 return (
@@ -195,7 +199,14 @@ class ProgressChart extends AbstractChart<
                     strokeLinejoin="round"
                     d={pie.curves[0].sector.path.print()}
                     strokeWidth={strokeWidth}
-                    stroke={withColor(i)}
+                    stroke={
+                      this.props.withCustomBarColorFromData
+                        ? withColor(i)
+                        : this.props.chartConfig.color(
+                            (i / pies.length) * 0.5 + 0.5,
+                            i
+                          )
+                    }
                   />
                 );
               })}


### PR DESCRIPTION
Adds extra property 'colors' to ProgressChart data

e.g. 

```
const progressChartData = {
  labels: ["Swim", "Bike", "Run"], // optional
  data: [0.2, 0.5, 0.3],
  colors: ["#dfe4ea", "#ced6e0", "#a4b0be"]
};
```

can be switched on by setting withCustomBarColorFromData to true

e.g.

```
 <ProgressChart
         data={progressChartData}
         width={width}
         height={height}
         chartConfig={chartConfig}
         style={graphStyle}
         hideLegend={false}
         withCustomBarColorFromData={true}
/>
``` 