### PR TITLE
Added "fromNumber" prop to abstract chart

### DIFF
--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -5,6 +5,7 @@ import { ChartConfig, Dataset, PartialBy } from "./HelperTypes";
 
 export interface AbstractChartProps {
   fromZero?: boolean;
+  fromNumber?: number;
   chartConfig?: AbstractChartConfig;
   yAxisLabel?: string;
   yAxisSuffix?: string;
@@ -40,6 +41,11 @@ class AbstractChart<
   calcScaler = (data: number[]) => {
     if (this.props.fromZero) {
       return Math.max(...data, 0) - Math.min(...data, 0) || 1;
+    } else if (this.props.fromNumber) {
+      return (
+        Math.max(...data, this.props.fromNumber) -
+          Math.min(...data, this.props.fromNumber) || 1
+      );
     } else {
       return Math.max(...data) - Math.min(...data) || 1;
     }


### PR DESCRIPTION
This enables the user to specify a number where the y axis should start from. This is mostly a feature that I would like but I cannot currently override by extending the classes that this library offers.