### PR TITLE
Adds dash support to the LineChart.

### DIFF
--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -22,6 +22,12 @@ export interface Dataset {
 
   /** Unique key **/
   key?: string | number;
+
+  /** Stroke Dash Array */
+  strokeDashArray?: number[];
+
+  /** Stroke Dash Offset */
+  strokeDashOffset?: number;
 }
 
 export interface ChartData {

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -640,6 +640,8 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
           fill="none"
           stroke={this.getColor(dataset, 0.2)}
           strokeWidth={this.getStrokeWidth(dataset)}
+          strokeDasharray={dataset.strokeDashArray}
+          strokeDashoffset={dataset.strokeDashOffset}
         />
       );
     });
@@ -721,6 +723,8 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
           fill="none"
           stroke={this.getColor(dataset, 0.2)}
           strokeWidth={this.getStrokeWidth(dataset)}
+          strokeDasharray={dataset.strokeDashArray}
+          strokeDashoffset={dataset.strokeDashOffset}
         />
       );
     });


### PR DESCRIPTION
Adds the ability to add dashes to the LineChart and BezierLineChart via `strokeDashArray` and `strokeDashOffset` properties on the individual data sets. These properties are already properties on the svg elements from `react-native-svg`, this just exposes them.