### PR TITLE
Support custom Y labels in StackedBarChart

### DIFF
--- a/App.js
+++ b/App.js
@@ -51,6 +51,12 @@ const chartConfigs = [
     color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`
   },
   {
+    backgroundColor: "#ffffff",
+    backgroundGradientFrom: "#ffffff",
+    backgroundGradientTo: "#ffffff",
+    color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`
+  },
+  {
     backgroundColor: "#26872a",
     backgroundGradientFrom: "#43a047",
     backgroundGradientTo: "#66bb6a",
@@ -171,6 +177,19 @@ export default class App extends React.Component {
                 width={width}
                 height={220}
                 chartConfig={chartConfig}
+              />
+              <Text style={labelStyle}>
+                Stacked Bar Graph with custom Y labels
+              </Text>
+              <StackedBarChart
+                style={graphStyle}
+                data={stackedBarGraphData}
+                width={width}
+                height={220}
+                chartConfig={chartConfig}
+                formatYLabel={input => {
+                  return +input * 2;
+                }}
               />
               <Text style={labelStyle}>Stacked Bar Graph Percentile</Text>
               <StackedBarChart

--- a/src/StackedBarChart.tsx
+++ b/src/StackedBarChart.tsx
@@ -48,6 +48,8 @@ export interface StackedBarChartProps extends AbstractChartProps {
   segments?: number;
 
   percentile?: boolean;
+
+  formatYLabel?: (yLabel: string) => string;
 }
 
 type StackedBarChartState = {};
@@ -184,7 +186,10 @@ class StackedBarChart extends AbstractChart<
       withVerticalLabels = true,
       segments = 4,
       decimalPlaces,
-      percentile = false
+      percentile = false,
+      formatYLabel = (yLabel: string) => {
+        return yLabel;
+      }
     } = this.props;
 
     const { borderRadius = 0 } = style;
@@ -240,7 +245,8 @@ class StackedBarChart extends AbstractChart<
                   data: [0, border],
                   paddingTop,
                   paddingRight,
-                  decimalPlaces
+                  decimalPlaces,
+                  formatYLabel
                 })
               : null}
           </G>


### PR DESCRIPTION
Support for custom Y labels added, by exposing the already existing `formatYLabel` function in `StackedBarChartProps`.

The function acts as a mapper of a default label to a custom label. The number of labels is equal to `segments` props.
