### PR TITLE
StackedBarChart - use full width when legend is hidden

### DIFF
--- a/src/StackedBarChart.tsx
+++ b/src/StackedBarChart.tsx
@@ -184,7 +184,8 @@ class StackedBarChart extends AbstractChart<
       withVerticalLabels = true,
       segments = 4,
       decimalPlaces,
-      percentile = false
+      percentile = false,
+      hideLegend = false
     } = this.props;
 
     const { borderRadius = 0 } = style;
@@ -209,7 +210,8 @@ class StackedBarChart extends AbstractChart<
       border = max;
     }
 
-    var stackedBar = data.legend && data.legend.length == 0 ? false : true;
+    const showLegend = !hideLegend && data.legend && data.legend.length != 0;
+    const stackedBar = showLegend;
 
     return (
       <View style={style}>
@@ -267,8 +269,7 @@ class StackedBarChart extends AbstractChart<
               stackedBar
             })}
           </G>
-          {data.legend &&
-            data.legend.length != 0 &&
+          {showLegend &&
             this.renderLegend({
               ...config,
               legend: data.legend,


### PR DESCRIPTION
Currently, the bar draw area is limited to 0.7 of the available width, even if there is no legend. This PR allows using the "legend" space for bar drawing, in case if no legend is provided, or if `hideLegend` prop is passed.
