### PR TITLE
Added repo links in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,11 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/indiespirit/react-native-chart-kit",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/indiespirit/react-native-chart-kit"
   }
 }


### PR DESCRIPTION
Certain properties in package.json file which is used to locate the original repo in npm is missing like `repository` and `homepage`.