### PR TITLE
Add fillShadowGradientTo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,27 +93,27 @@ const chartConfig = {
 };
 ```
 
-| Property                      | Type               | Description                                                                                            |
-| ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
-| backgroundGradientFrom        | string             | Defines the first color in the linear gradient of a chart's background                                 |
-| backgroundGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of a chart's background                         |
-| backgroundGradientTo          | string             | Defines the second color in the linear gradient of a chart's background                                |
-| backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
-| fillShadowGradientFrom        | string             | Defines the first color in the linear gradient of the area under data                                  |
-| fillShadowGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of the area under data                          |
-| fillShadowGradientFromOffset  | Number             | Defines the first color offset in the linear gradient of the area under data                           |
-| fillShadowGradientTo          | string             | Defines the second color in the linear gradient of the area under data                                 |
-| fillShadowGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of the area under data                         |
-| fillShadowGradientToOffset    | Number             | Defines the second color offset in the linear gradient of the area under data                          |
-| useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
-| color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
-| strokeWidth                   | Number             | Defines the base stroke width in a chart                                                               |
-| barPercentage                 | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |
-| barRadius                     | Number             | Defines the radius of each bar                                                                         |
-| propsForBackgroundLines       | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                |
-| propsForLabels                | props              | Override styles of the labels, refer to react-native-svg's Text documentation                          |
-| propsForVerticalLabels        | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                     |
-| propsForHorizontalLabels      | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                   |
+| Property                      | Type               | Description                                                                                                                          |
+| ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| backgroundGradientFrom        | string             | Defines the first color in the linear gradient of a chart's background                                                               |
+| backgroundGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of a chart's background                                                       |
+| backgroundGradientTo          | string             | Defines the second color in the linear gradient of a chart's background                                                              |
+| backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                                                      |
+| fillShadowGradientFrom        | string             | Defines the first color in the linear gradient of the area under data (can also be specified as `fillShadowGradient`)                |
+| fillShadowGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of the area under data (can also be specified as `fillShadowGradientOpacity`) |
+| fillShadowGradientFromOffset  | Number             | Defines the first color offset in the linear gradient of the area under data                                                         |
+| fillShadowGradientTo          | string             | Defines the second color in the linear gradient of the area under data                                                               |
+| fillShadowGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of the area under data                                                       |
+| fillShadowGradientToOffset    | Number             | Defines the second color offset in the linear gradient of the area under data                                                        |
+| useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                                                    |
+| color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart                               |
+| strokeWidth                   | Number             | Defines the base stroke width in a chart                                                                                             |
+| barPercentage                 | Number             | Defines the percent (0-1) of the available width each bar width in a chart                                                           |
+| barRadius                     | Number             | Defines the radius of each bar                                                                                                       |
+| propsForBackgroundLines       | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                                              |
+| propsForLabels                | props              | Override styles of the labels, refer to react-native-svg's Text documentation                                                        |
+| propsForVerticalLabels        | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                                                   |
+| propsForHorizontalLabels      | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                                                 |
 
 ## Responsive charts
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ const chartConfig = {
 | backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                                                      |
 | fillShadowGradientFrom        | string             | Defines the first color in the linear gradient of the area under data (can also be specified as `fillShadowGradient`)                |
 | fillShadowGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of the area under data (can also be specified as `fillShadowGradientOpacity`) |
-| fillShadowGradientFromOffset  | Number             | Defines the first color offset in the linear gradient of the area under data                                                         |
+| fillShadowGradientFromOffset  | Number             | Defines the first color offset (0-1) in the linear gradient of the area under data                                                   |
 | fillShadowGradientTo          | string             | Defines the second color in the linear gradient of the area under data                                                               |
 | fillShadowGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of the area under data                                                       |
-| fillShadowGradientToOffset    | Number             | Defines the second color offset in the linear gradient of the area under data                                                        |
+| fillShadowGradientToOffset    | Number             | Defines the second color offset (0-1) in the linear gradient of the area under data                                                  |
 | useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                                                    |
 | color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart                               |
 | strokeWidth                   | Number             | Defines the base stroke width in a chart                                                                                             |

--- a/README.md
+++ b/README.md
@@ -93,25 +93,25 @@ const chartConfig = {
 };
 ```
 
-| Property                          | Type               | Description                                                                                            |
-| --------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
-| backgroundGradientFrom            | string             | Defines the first color in the linear gradient of a chart's background                                 |
-| backgroundGradientFromOpacity     | Number             | Defines the first color opacity in the linear gradient of a chart's background                         |
-| backgroundGradientTo              | string             | Defines the second color in the linear gradient of a chart's background                                |
-| backgroundGradientToOpacity       | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
-| fillShadowGradientFrom            | string             | Defines the color of the area under data                                                               |
-| fillShadowGradientFromOpacity     | Number             | Defines the initial opacity of the area under data                                                     |
-| fillShadowGradientTo              | string             | Defines the color of the area under data                                                               |
-| fillShadowGradientToOpacity       | Number             | Defines the initial opacity of the area under data                                                     |
-| useShadowColorFromDataset         | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
-| color                             | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
-| strokeWidth                       | Number             | Defines the base stroke width in a chart                                                               |
-| barPercentage                     | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |
-| barRadius                         | Number             | Defines the radius of each bar                                                                         |
-| propsForBackgroundLines           | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                |
-| propsForLabels                    | props              | Override styles of the labels, refer to react-native-svg's Text documentation                          |
-| propsForVerticalLabels            | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                     |
-| propsForHorizontalLabels          | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                   |
+| Property                      | Type               | Description                                                                                            |
+| ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
+| backgroundGradientFrom        | string             | Defines the first color in the linear gradient of a chart's background                                 |
+| backgroundGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of a chart's background                         |
+| backgroundGradientTo          | string             | Defines the second color in the linear gradient of a chart's background                                |
+| backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
+| fillShadowGradientFrom        | string             | Defines the first color in the linear gradient of the area under data                                  |
+| fillShadowGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of the area under data                          |
+| fillShadowGradientTo          | string             | Defines the second color in the linear gradient of the area under data                                 |
+| fillShadowGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of the area under data                         |
+| useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
+| color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
+| strokeWidth                   | Number             | Defines the base stroke width in a chart                                                               |
+| barPercentage                 | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |
+| barRadius                     | Number             | Defines the radius of each bar                                                                         |
+| propsForBackgroundLines       | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                |
+| propsForLabels                | props              | Override styles of the labels, refer to react-native-svg's Text documentation                          |
+| propsForVerticalLabels        | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                     |
+| propsForHorizontalLabels      | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                   |
 
 ## Responsive charts
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ const chartConfig = {
 | backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
 | fillShadowGradientFrom        | string             | Defines the first color in the linear gradient of the area under data                                  |
 | fillShadowGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of the area under data                          |
+| fillShadowGradientFromOffset  | Number             | Defines the first color offset in the linear gradient of the area under data                           |
 | fillShadowGradientTo          | string             | Defines the second color in the linear gradient of the area under data                                 |
 | fillShadowGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of the area under data                         |
+| fillShadowGradientToOffset    | Number             | Defines the second color offset in the linear gradient of the area under data                          |
 | useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
 | color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
 | strokeWidth                   | Number             | Defines the base stroke width in a chart                                                               |

--- a/README.md
+++ b/README.md
@@ -93,23 +93,25 @@ const chartConfig = {
 };
 ```
 
-| Property                      | Type               | Description                                                                                            |
-| ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
-| backgroundGradientFrom        | string             | Defines the first color in the linear gradient of a chart's background                                 |
-| backgroundGradientFromOpacity | Number             | Defines the first color opacity in the linear gradient of a chart's background                         |
-| backgroundGradientTo          | string             | Defines the second color in the linear gradient of a chart's background                                |
-| backgroundGradientToOpacity   | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
-| fillShadowGradient            | string             | Defines the color of the area under data                                                               |
-| fillShadowGradientOpacity     | Number             | Defines the initial opacity of the area under data                                                     |
-| useShadowColorFromDataset     | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
-| color                         | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
-| strokeWidth                   | Number             | Defines the base stroke width in a chart                                                               |
-| barPercentage                 | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |
-| barRadius                     | Number             | Defines the radius of each bar                                                                         |
-| propsForBackgroundLines       | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                |
-| propsForLabels                | props              | Override styles of the labels, refer to react-native-svg's Text documentation                          |
-| propsForVerticalLabels        | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                     |
-| propsForHorizontalLabels      | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                   |
+| Property                          | Type               | Description                                                                                            |
+| --------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
+| backgroundGradientFrom            | string             | Defines the first color in the linear gradient of a chart's background                                 |
+| backgroundGradientFromOpacity     | Number             | Defines the first color opacity in the linear gradient of a chart's background                         |
+| backgroundGradientTo              | string             | Defines the second color in the linear gradient of a chart's background                                |
+| backgroundGradientToOpacity       | Number             | Defines the second color opacity in the linear gradient of a chart's background                        |
+| fillShadowGradientFrom            | string             | Defines the color of the area under data                                                               |
+| fillShadowGradientFromOpacity     | Number             | Defines the initial opacity of the area under data                                                     |
+| fillShadowGradientTo              | string             | Defines the color of the area under data                                                               |
+| fillShadowGradientToOpacity       | Number             | Defines the initial opacity of the area under data                                                     |
+| useShadowColorFromDataset         | Boolean            | Defines the option to use color from dataset to each chart data. Default is false                      |
+| color                             | function => string | Defines the base color function that is used to calculate colors of labels and sectors used in a chart |
+| strokeWidth                       | Number             | Defines the base stroke width in a chart                                                               |
+| barPercentage                     | Number             | Defines the percent (0-1) of the available width each bar width in a chart                             |
+| barRadius                         | Number             | Defines the radius of each bar                                                                         |
+| propsForBackgroundLines           | props              | Override styles of the background lines, refer to react-native-svg's Line documentation                |
+| propsForLabels                    | props              | Override styles of the labels, refer to react-native-svg's Text documentation                          |
+| propsForVerticalLabels            | props              | Override styles of vertical labels, refer to react-native-svg's Text documentation                     |
+| propsForHorizontalLabels          | props              | Override styles of horizontal labels, refer to react-native-svg's Text documentation                   |
 
 ## Responsive charts
 

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/indiespirit/react-native-chart-kit"
+  },
+  "resolutions": {
+    "@types/react": "16.14.8"
   }
 }

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -380,8 +380,10 @@ class AbstractChart<
         | "fillShadowGradientOpacity"
         | "fillShadowGradientFrom"
         | "fillShadowGradientFromOpacity"
+        | "fillShadowGradientFromOffset"
         | "fillShadowGradientTo"
         | "fillShadowGradientToOpacity"
+        | "fillShadowGradientToOffset"
       >,
       | "width"
       | "height"
@@ -395,8 +397,10 @@ class AbstractChart<
       | "fillShadowGradientOpacity"
       | "fillShadowGradientFrom"
       | "fillShadowGradientFromOpacity"
+      | "fillShadowGradientFromOffset"
       | "fillShadowGradientTo"
       | "fillShadowGradientToOpacity"
+      | "fillShadowGradientToOffset"
     >
   ) => {
     const {
@@ -437,6 +441,12 @@ class AbstractChart<
       ? config.fillShadowGradientFromOpacity
       : 0.1;
 
+    const fillShadowGradientFromOffset = config.hasOwnProperty(
+      "fillShadowGradientFromOffset"
+    )
+      ? config.fillShadowGradientFromOffset
+      : 0;
+
     const fillShadowGradientTo = config.hasOwnProperty("fillShadowGradientTo")
       ? config.fillShadowGradientTo
       : this.props.chartConfig.color(1.0);
@@ -446,6 +456,12 @@ class AbstractChart<
     )
       ? config.fillShadowGradientToOpacity
       : 0.1;
+
+    const fillShadowGradientToOffset = config.hasOwnProperty(
+      "fillShadowGradientToOffset"
+    )
+      ? config.fillShadowGradientToOffset
+      : 1;
 
     return (
       <Defs>
@@ -480,7 +496,7 @@ class AbstractChart<
               gradientUnits="userSpaceOnUse"
             >
               <Stop
-                offset="0"
+                offset={fillShadowGradientFromOffset}
                 stopColor={
                   dataset.color
                     ? dataset.color(1.0)
@@ -491,7 +507,7 @@ class AbstractChart<
                 }
               />
               <Stop
-                offset="1"
+                offset={fillShadowGradientToOffset}
                 stopColor={
                   dataset.color
                     ? dataset.color(
@@ -514,14 +530,14 @@ class AbstractChart<
             gradientUnits="userSpaceOnUse"
           >
             <Stop
-              offset="0"
+              offset={fillShadowGradientFromOffset}
               stopColor={fillShadowGradientFrom || fillShadowGradient}
               stopOpacity={
                 fillShadowGradientFromOpacity || fillShadowGradientOpacity
               }
             />
             <Stop
-              offset="1"
+              offset={fillShadowGradientToOffset}
               stopColor={
                 fillShadowGradientTo ||
                 fillShadowGradientFrom ||

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -376,8 +376,10 @@ class AbstractChart<
         AbstractChartConfig,
         | "backgroundGradientFromOpacity"
         | "backgroundGradientToOpacity"
-        | "fillShadowGradient"
-        | "fillShadowGradientOpacity"
+        | "fillShadowGradientFrom"
+        | "fillShadowGradientFromOpacity"
+        | "fillShadowGradientTo"
+        | "fillShadowGradientToOpacity"
       >,
       | "width"
       | "height"
@@ -387,8 +389,10 @@ class AbstractChart<
       | "data"
       | "backgroundGradientFromOpacity"
       | "backgroundGradientToOpacity"
-      | "fillShadowGradient"
-      | "fillShadowGradientOpacity"
+      | "fillShadowGradientFrom"
+      | "fillShadowGradientFromOpacity"
+      | "fillShadowGradientTo"
+      | "fillShadowGradientToOpacity"
     >
   ) => {
     const {
@@ -407,16 +411,26 @@ class AbstractChart<
       ? config.backgroundGradientToOpacity
       : 1.0;
 
-    const fillShadowGradient = config.hasOwnProperty("fillShadowGradient")
-      ? config.fillShadowGradient
+    const fillShadowGradientFrom = config.hasOwnProperty("fillShadowGradientFrom")
+      ? config.fillShadowGradientFrom
       : this.props.chartConfig.color(1.0);
 
-    const fillShadowGradientOpacity = config.hasOwnProperty(
-      "fillShadowGradientOpacity"
+    const fillShadowGradientFromOpacity = config.hasOwnProperty(
+      "fillShadowGradientFromOpacity"
     )
-      ? config.fillShadowGradientOpacity
+      ? config.fillShadowGradientFromOpacity
       : 0.1;
 
+    const fillShadowGradientTo = config.hasOwnProperty("fillShadowGradientTo")
+      ? config.fillShadowGradientTo
+      : this.props.chartConfig.color(1.0);
+
+    const fillShadowGradientToOpacity = config.hasOwnProperty(
+      "fillShadowGradientToOpacity"
+    )
+      ? config.fillShadowGradientToOpacity
+      : 0.1;
+    
     return (
       <Defs>
         <LinearGradient
@@ -441,7 +455,7 @@ class AbstractChart<
         {useShadowColorFromDataset ? (
           data.map((dataset, index) => (
             <LinearGradient
-              id={`fillShadowGradient_${index}`}
+              id={`fillShadowGradientFrom_${index}`}
               key={`${index}`}
               x1={0}
               y1={0}
@@ -452,16 +466,16 @@ class AbstractChart<
               <Stop
                 offset="0"
                 stopColor={
-                  dataset.color ? dataset.color(1.0) : fillShadowGradient
+                  dataset.color ? dataset.color(1.0) : fillShadowGradientFrom
                 }
-                stopOpacity={fillShadowGradientOpacity}
+                stopOpacity={fillShadowGradientFromOpacity}
               />
               <Stop
                 offset="1"
                 stopColor={
                   dataset.color
-                    ? dataset.color(fillShadowGradientOpacity)
-                    : fillShadowGradient
+                    ? dataset.color(fillShadowGradientFromOpacity)
+                    : fillShadowGradientFrom
                 }
                 stopOpacity="0"
               />
@@ -469,7 +483,7 @@ class AbstractChart<
           ))
         ) : (
           <LinearGradient
-            id="fillShadowGradient"
+            id="fillShadowGradientFrom"
             x1={0}
             y1={0}
             x2={0}
@@ -478,10 +492,10 @@ class AbstractChart<
           >
             <Stop
               offset="0"
-              stopColor={fillShadowGradient}
-              stopOpacity={fillShadowGradientOpacity}
+              stopColor={fillShadowGradientFrom}
+              stopOpacity={fillShadowGradientFromOpacity}
             />
-            <Stop offset="1" stopColor={fillShadowGradient} stopOpacity="0" />
+            <Stop offset="1" stopColor={fillShadowGradientTo || fillShadowGradientFrom} stopOpacity="0" />
           </LinearGradient>
         )}
       </Defs>

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -376,6 +376,8 @@ class AbstractChart<
         AbstractChartConfig,
         | "backgroundGradientFromOpacity"
         | "backgroundGradientToOpacity"
+        | "fillShadowGradient"
+        | "fillShadowGradientOpacity"
         | "fillShadowGradientFrom"
         | "fillShadowGradientFromOpacity"
         | "fillShadowGradientTo"
@@ -389,6 +391,8 @@ class AbstractChart<
       | "data"
       | "backgroundGradientFromOpacity"
       | "backgroundGradientToOpacity"
+      | "fillShadowGradient"
+      | "fillShadowGradientOpacity"
       | "fillShadowGradientFrom"
       | "fillShadowGradientFromOpacity"
       | "fillShadowGradientTo"
@@ -411,7 +415,19 @@ class AbstractChart<
       ? config.backgroundGradientToOpacity
       : 1.0;
 
-    const fillShadowGradientFrom = config.hasOwnProperty("fillShadowGradientFrom")
+    const fillShadowGradient = config.hasOwnProperty("fillShadowGradient")
+      ? config.fillShadowGradient
+      : this.props.chartConfig.color(1.0);
+
+    const fillShadowGradientOpacity = config.hasOwnProperty(
+      "fillShadowGradientOpacity"
+    )
+      ? config.fillShadowGradientOpacity
+      : 0.1;
+
+    const fillShadowGradientFrom = config.hasOwnProperty(
+      "fillShadowGradientFrom"
+    )
       ? config.fillShadowGradientFrom
       : this.props.chartConfig.color(1.0);
 
@@ -430,7 +446,7 @@ class AbstractChart<
     )
       ? config.fillShadowGradientToOpacity
       : 0.1;
-    
+
     return (
       <Defs>
         <LinearGradient
@@ -466,18 +482,25 @@ class AbstractChart<
               <Stop
                 offset="0"
                 stopColor={
-                  dataset.color ? dataset.color(1.0) : fillShadowGradientFrom
+                  dataset.color
+                    ? dataset.color(1.0)
+                    : fillShadowGradientFrom || fillShadowGradient
                 }
-                stopOpacity={fillShadowGradientFromOpacity}
+                stopOpacity={
+                  fillShadowGradientFromOpacity || fillShadowGradientOpacity
+                }
               />
               <Stop
                 offset="1"
                 stopColor={
                   dataset.color
-                    ? dataset.color(fillShadowGradientFromOpacity)
-                    : fillShadowGradientFrom
+                    ? dataset.color(
+                        fillShadowGradientFromOpacity ||
+                          fillShadowGradientOpacity
+                      )
+                    : fillShadowGradientFrom || fillShadowGradient
                 }
-                stopOpacity="0"
+                stopOpacity={fillShadowGradientToOpacity || 0}
               />
             </LinearGradient>
           ))
@@ -492,10 +515,20 @@ class AbstractChart<
           >
             <Stop
               offset="0"
-              stopColor={fillShadowGradientFrom}
-              stopOpacity={fillShadowGradientFromOpacity}
+              stopColor={fillShadowGradientFrom || fillShadowGradient}
+              stopOpacity={
+                fillShadowGradientFromOpacity || fillShadowGradientOpacity
+              }
             />
-            <Stop offset="1" stopColor={fillShadowGradientTo || fillShadowGradientFrom} stopOpacity={fillShadowGradientToOpacity || 0} />
+            <Stop
+              offset="1"
+              stopColor={
+                fillShadowGradientTo ||
+                fillShadowGradientFrom ||
+                fillShadowGradient
+              }
+              stopOpacity={fillShadowGradientToOpacity || 0}
+            />
           </LinearGradient>
         )}
       </Defs>

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -495,7 +495,7 @@ class AbstractChart<
               stopColor={fillShadowGradientFrom}
               stopOpacity={fillShadowGradientFromOpacity}
             />
-            <Stop offset="1" stopColor={fillShadowGradientTo || fillShadowGradientFrom} stopOpacity="0" />
+            <Stop offset="1" stopColor={fillShadowGradientTo || fillShadowGradientFrom} stopOpacity={fillShadowGradientToOpacity || 0} />
           </LinearGradient>
         )}
       </Defs>

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -433,13 +433,13 @@ class AbstractChart<
       "fillShadowGradientFrom"
     )
       ? config.fillShadowGradientFrom
-      : this.props.chartConfig.color(1.0);
+      : fillShadowGradient;
 
     const fillShadowGradientFromOpacity = config.hasOwnProperty(
       "fillShadowGradientFromOpacity"
     )
       ? config.fillShadowGradientFromOpacity
-      : 0.1;
+      : fillShadowGradientOpacity;
 
     const fillShadowGradientFromOffset = config.hasOwnProperty(
       "fillShadowGradientFromOffset"
@@ -498,23 +498,16 @@ class AbstractChart<
               <Stop
                 offset={fillShadowGradientFromOffset}
                 stopColor={
-                  dataset.color
-                    ? dataset.color(1.0)
-                    : fillShadowGradientFrom || fillShadowGradient
+                  dataset.color ? dataset.color(1.0) : fillShadowGradientFrom
                 }
-                stopOpacity={
-                  fillShadowGradientFromOpacity || fillShadowGradientOpacity
-                }
+                stopOpacity={fillShadowGradientFromOpacity}
               />
               <Stop
                 offset={fillShadowGradientToOffset}
                 stopColor={
                   dataset.color
-                    ? dataset.color(
-                        fillShadowGradientFromOpacity ||
-                          fillShadowGradientOpacity
-                      )
-                    : fillShadowGradientFrom || fillShadowGradient
+                    ? dataset.color(fillShadowGradientFromOpacity)
+                    : fillShadowGradientFrom
                 }
                 stopOpacity={fillShadowGradientToOpacity || 0}
               />
@@ -531,18 +524,12 @@ class AbstractChart<
           >
             <Stop
               offset={fillShadowGradientFromOffset}
-              stopColor={fillShadowGradientFrom || fillShadowGradient}
-              stopOpacity={
-                fillShadowGradientFromOpacity || fillShadowGradientOpacity
-              }
+              stopColor={fillShadowGradientFrom}
+              stopOpacity={fillShadowGradientFromOpacity}
             />
             <Stop
               offset={fillShadowGradientToOffset}
-              stopColor={
-                fillShadowGradientTo ||
-                fillShadowGradientFrom ||
-                fillShadowGradient
-              }
+              stopColor={fillShadowGradientTo || fillShadowGradientFrom}
               stopOpacity={fillShadowGradientToOpacity || 0}
             />
           </LinearGradient>

--- a/src/BarChart.tsx
+++ b/src/BarChart.tsx
@@ -94,7 +94,7 @@ class BarChart extends AbstractChart<BarChartProps, BarChartState> {
           fill={
             withCustomBarColorFromData
               ? `url(#customColor_0_${i})`
-              : "url(#fillShadowGradient)"
+              : "url(#fillShadowGradientFrom)"
           }
         />
       );

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -61,6 +61,9 @@ export interface ChartConfig {
   fillShadowGradientFromOpacity?: number;
   fillShadowGradientTo?: string;
   fillShadowGradientToOpacity?: number;
+  // these are here to maintain backwards compatibility:
+  fillShadowGradient?: string;
+  fillShadowGradientOpacity?: number;
   /**
    * Defines the option to use color from dataset to each chart data
    */

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -63,6 +63,10 @@ export interface ChartConfig {
    */
   fillShadowGradientFromOpacity?: number;
   /**
+   * Defines the first color offset in the linear gradient of the area under data
+   */
+  fillShadowGradientFromOffset?: number;
+  /**
    * Defines the second color in the linear gradient of the area under data
    */
   fillShadowGradientTo?: string;
@@ -70,6 +74,10 @@ export interface ChartConfig {
    * Defines the second color opacity in the linear gradient of the area under data
    */
   fillShadowGradientToOpacity?: number;
+  /**
+   * Defines the second color offset in the linear gradient of the area under data
+   */
+  fillShadowGradientToOffset?: number;
   /**
    * Defines the previous options to maintain backwards compatibility
    */

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -55,13 +55,24 @@ export interface ChartConfig {
    */
   backgroundGradientToOpacity?: number;
   /**
-   * Defines the linear gradient for the fill shadow
+   * Defines the first color in the linear gradient of the area under data
    */
   fillShadowGradientFrom?: string;
+  /**
+   * Defines the first color opacity in the linear gradient of the area under data
+   */
   fillShadowGradientFromOpacity?: number;
+  /**
+   * Defines the second color in the linear gradient of the area under data
+   */
   fillShadowGradientTo?: string;
+  /**
+   * Defines the second color opacity in the linear gradient of the area under data
+   */
   fillShadowGradientToOpacity?: number;
-  // these are here to maintain backwards compatibility:
+  /**
+   * Defines the previous options to maintain backwards compatibility
+   */
   fillShadowGradient?: string;
   fillShadowGradientOpacity?: number;
   /**

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -54,8 +54,13 @@ export interface ChartConfig {
    * Defines the second color opacity in the linear gradient of a chart's background
    */
   backgroundGradientToOpacity?: number;
-  fillShadowGradient?: string;
-  fillShadowGradientOpacity?: number;
+  /**
+   * Defines the linear gradient for the fill shadow
+   */
+  fillShadowGradientFrom?: string;
+  fillShadowGradientFromOpacity?: number;
+  fillShadowGradientTo?: string;
+  fillShadowGradientToOpacity?: number;
   /**
    * Defines the option to use color from dataset to each chart data
    */

--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -55,6 +55,11 @@ export interface ChartConfig {
    */
   backgroundGradientToOpacity?: number;
   /**
+   * Defines the previous options to maintain backwards compatibility
+   */
+  fillShadowGradient?: string;
+  fillShadowGradientOpacity?: number;
+  /**
    * Defines the first color in the linear gradient of the area under data
    */
   fillShadowGradientFrom?: string;
@@ -78,11 +83,6 @@ export interface ChartConfig {
    * Defines the second color offset in the linear gradient of the area under data
    */
   fillShadowGradientToOffset?: number;
-  /**
-   * Defines the previous options to maintain backwards compatibility
-   */
-  fillShadowGradient?: string;
-  fillShadowGradientOpacity?: number;
   /**
    * Defines the option to use color from dataset to each chart data
    */

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -584,7 +584,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                 (dataset.data.length - 1)},${(height / 4) * 3 +
               paddingTop} ${paddingRight},${(height / 4) * 3 + paddingTop}`
           }
-          fill={`url(#fillShadowGradient${
+          fill={`url(#fillShadowGradientFrom${
             useColorFromDataset ? `_${index}` : ""
           })`}
           strokeWidth={0}
@@ -761,7 +761,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
         <Path
           key={index}
           d={d}
-          fill={`url(#fillShadowGradient${
+          fill={`url(#fillShadowGradientFrom${
             useColorFromDataset ? `_${index}` : ""
           })`}
           strokeWidth={0}


### PR DESCRIPTION
In an effort to allow for a linear gradient shadow fill that blends one color into another, this PR replaces `fillShadowGradient` and `fillShadowGradientOpacity` with new "To" and "From" options:

- `fillShadowGradientFrom`
- `fillShadowGradientFromOpacity`
- `fillShadowGradientTo`
- `fillShadowGradientToOpacity`

In the `AbstractChart` component, if `fillShadowGradientTo` is provided in the chart config, then it's used for the second `<Stop>` SVG element, otherwise `fillShadowGradientFrom` is used. Similarly, if `fillShadowGradientToOpacity` is provided, then that's used for the second `<Stop>` SVG element's opacity, otherwise a default value of 0 is used.

Lastly, it maintains backwards compatibility with the current `fillShadowGradient` and `fillShadowGradientOpacity` options.