### PR TITLE
Fix error when using withScrollableDot

### DIFF
--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -982,7 +982,8 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   contentOffset: { x: scrollableDotHorizontalOffset }
                 }
               }
-            ])}
+            ], { useNativeDriver: false }
+            )}
             horizontal
             bounces={false}
           />


### PR DESCRIPTION
To fix React Native Error: “Animated.event now requires a second argument for options” when using withScrollableDot for LineChart