### PR TITLE
[LineChart] Ability to specify whether to render line shadows at a dataset level

### DIFF
--- a/src/HelperTypes.ts
+++ b/src/HelperTypes.ts
@@ -17,6 +17,9 @@ export interface Dataset {
   /** A boolean indicating whether to render dots for this line */
   withDots?: boolean;
 
+  /** A boolean indicating whether to render shadows for this dataset */
+  withShadow?: boolean;
+
   /** Override of LineChart's withScrollableDot property just for this dataset */
   withScrollableDot?: boolean;
 

--- a/src/contribution-graph/index.tsx
+++ b/src/contribution-graph/index.tsx
@@ -3,7 +3,7 @@ import { ViewStyle } from "react-native";
 import { AbstractChartProps } from "../AbstractChart";
 import ContributionGraph, {
   ContributionChartValue,
-  TooltipDataAttrs
+  TooltipDataAttrs,
 } from "./ContributionGraph";
 
 export interface ContributionGraphProps extends AbstractChartProps {
@@ -19,7 +19,7 @@ export interface ContributionGraphProps extends AbstractChartProps {
   showOutOfRangeDays?: boolean;
   accessor?: string;
   getMonthLabel?: (monthIndex: number) => string;
-  onDayPress?: ({ count: number, date: Date }) => void;
+  onDayPress?: ({ count, date }: { count: number; date: Date }) => void;
   classForValue?: (value: string) => string;
   style?: Partial<ViewStyle>;
   titleForValue?: (value: ContributionChartValue) => string;

--- a/src/line-chart/LegendItem.tsx
+++ b/src/line-chart/LegendItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Color, Rect, Text, TextProps } from "react-native-svg";
+import { Rect, Text, TextProps } from "react-native-svg";
+import { ColorValue } from "react-native";
 
 const CIRCLE_WIDTH = 16;
 const PADDING_LEFT = 4;
@@ -10,7 +11,7 @@ export type LegendItemProps = {
   index: number;
   legendOffset: number;
   legendText: string;
-  iconColor: Color;
+  iconColor: ColorValue;
   labelProps: TextProps;
 };
 

--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   TextInput,
   View,
-  ViewStyle
+  ViewStyle,
 } from "react-native";
 import {
   Circle,
@@ -14,12 +14,12 @@ import {
   Polygon,
   Polyline,
   Rect,
-  Svg
+  Svg,
 } from "react-native-svg";
 
 import AbstractChart, {
   AbstractChartConfig,
-  AbstractChartProps
+  AbstractChartProps,
 } from "../AbstractChart";
 import { ChartData, Dataset } from "../HelperTypes";
 import { LegendItem } from "./LegendItem";
@@ -224,7 +224,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
   label = React.createRef<TextInput>();
 
   state = {
-    scrollableDotHorizontalOffset: new Animated.Value(0)
+    scrollableDotHorizontalOffset: new Animated.Value(0),
   };
 
   getColor = (dataset: Dataset, opacity: number) => {
@@ -260,7 +260,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     height,
     paddingTop,
     paddingRight,
-    onDataPointClick
+    onDataPointClick,
   }: Pick<
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop"
@@ -276,10 +276,10 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       hidePointsAtIndex = [],
       renderDotContent = () => {
         return null;
-      }
+      },
     } = this.props;
     const xMax = this.getXMaxValues(data);
-    data.forEach(dataset => {
+    data.forEach((dataset) => {
       if (dataset.withDots == false) return;
 
       dataset.data.forEach((x, i) => {
@@ -304,7 +304,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             dataset,
             x: cx,
             y: cy,
-            getColor: opacity => this.getColor(dataset, opacity)
+            getColor: (opacity) => this.getColor(dataset, opacity),
           });
         };
 
@@ -351,9 +351,9 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     scrollableDotRadius,
     scrollableInfoViewStyle,
     scrollableInfoTextStyle,
-    scrollableInfoTextDecorator = x => `${x}`,
+    scrollableInfoTextDecorator = (x) => `${x}`,
     scrollableInfoSize,
-    scrollableInfoOffset
+    scrollableInfoOffset,
   }: AbstractChartConfig & {
     onDataPointClick: LineChartProps["onDataPointClick"];
     scrollableDotHorizontalOffset: Animated.Value;
@@ -370,7 +370,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     }
     let lastIndex: number;
 
-    scrollableDotHorizontalOffset.addListener(value => {
+    scrollableDotHorizontalOffset.addListener((value) => {
       const index = value.value / perData;
       if (!lastIndex) {
         lastIndex = index;
@@ -382,7 +382,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
 
       if (index >= data[0].data.length - 1) {
         this.label.current.setNativeProps({
-          text: scrollableInfoTextDecorator(Math.floor(data[0].data[0]))
+          text: scrollableInfoTextDecorator(Math.floor(data[0].data[0])),
         });
       } else {
         if (index > lastIndex) {
@@ -395,14 +395,14 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             this.label.current.setNativeProps({
               text: scrollableInfoTextDecorator(
                 Math.floor(base + percent * rest)
-              )
+              ),
             });
           } else {
             let rest = base - prev;
             this.label.current.setNativeProps({
               text: scrollableInfoTextDecorator(
                 Math.floor(base - percent * rest)
-              )
+              ),
             });
           }
         } else {
@@ -416,14 +416,14 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             this.label.current.setNativeProps({
               text: scrollableInfoTextDecorator(
                 Math.floor(base + percent * rest)
-              )
+              ),
             });
           } else {
             let rest = base - next;
             this.label.current.setNativeProps({
               text: scrollableInfoTextDecorator(
                 Math.floor(base - percent * rest)
-              )
+              ),
             });
           }
         }
@@ -431,7 +431,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       lastIndex = index;
     });
 
-    data.forEach(dataset => {
+    data.forEach((dataset) => {
       if (dataset.withScrollableDot == false) return;
 
       const perData = width / dataset.data.length;
@@ -470,25 +470,25 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       const translateX = scrollableDotHorizontalOffset.interpolate({
         inputRange: values,
         outputRange: xValues,
-        extrapolate: "clamp"
+        extrapolate: "clamp",
       });
 
       const translateY = scrollableDotHorizontalOffset.interpolate({
         inputRange: values,
         outputRange: yValues,
-        extrapolate: "clamp"
+        extrapolate: "clamp",
       });
 
       const labelTranslateX = scrollableDotHorizontalOffset.interpolate({
         inputRange: values,
         outputRange: xValuesLabel,
-        extrapolate: "clamp"
+        extrapolate: "clamp",
       });
 
       const labelTranslateY = scrollableDotHorizontalOffset.interpolate({
         inputRange: values,
         outputRange: yValuesLabel,
-        extrapolate: "clamp"
+        extrapolate: "clamp",
       });
 
       output.push([
@@ -499,11 +499,11 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             {
               transform: [
                 { translateX: labelTranslateX },
-                { translateY: labelTranslateY }
+                { translateY: labelTranslateY },
               ],
               width: scrollableInfoSize.width,
-              height: scrollableInfoSize.height
-            }
+              height: scrollableInfoSize.height,
+            },
           ]}
         >
           <TextInput
@@ -511,7 +511,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
               this.label.current.setNativeProps({
                 text: scrollableInfoTextDecorator(
                   Math.floor(data[0].data[data[0].data.length - 1])
-                )
+                ),
               });
             }}
             style={scrollableInfoTextStyle}
@@ -526,7 +526,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
           stroke={scrollableDotStrokeColor}
           strokeWidth={scrollableDotStrokeWidth}
           fill={scrollableDotFill}
-        />
+        />,
       ]);
     });
 
@@ -539,7 +539,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     paddingRight,
     paddingTop,
     data,
-    useColorFromDataset
+    useColorFromDataset,
   }: Pick<
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop"
@@ -553,7 +553,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
         paddingRight,
         paddingTop,
         data,
-        useColorFromDataset
+        useColorFromDataset,
       });
     }
 
@@ -561,6 +561,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     const baseHeight = this.calcBaseHeight(datas, height);
 
     return data.map((dataset, index) => {
+      if (dataset.withShadow == false) return;
       return (
         <Polygon
           key={index}
@@ -578,10 +579,13 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                 return `${x},${y}`;
               })
               .join(" ") +
-            ` ${paddingRight +
+            ` ${
+              paddingRight +
               ((width - paddingRight) / dataset.data.length) *
-                (dataset.data.length - 1)},${(height / 4) * 3 +
-              paddingTop} ${paddingRight},${(height / 4) * 3 + paddingTop}`
+                (dataset.data.length - 1)
+            },${(height / 4) * 3 + paddingTop} ${paddingRight},${
+              (height / 4) * 3 + paddingTop
+            }`
           }
           fill={`url(#fillShadowGradientFrom${
             useColorFromDataset ? `_${index}` : ""
@@ -598,7 +602,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     paddingRight,
     paddingTop,
     data,
-    linejoinType
+    linejoinType,
   }: Pick<
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop" | "linejoinType"
@@ -609,7 +613,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
         width,
         height,
         paddingRight,
-        paddingTop
+        paddingTop,
       });
     }
 
@@ -661,7 +665,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       height,
       paddingRight,
       paddingTop,
-      data
+      data,
     }: Pick<
       AbstractChartConfig,
       "width" | "height" | "paddingRight" | "paddingTop" | "data"
@@ -706,7 +710,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     width,
     height,
     paddingRight,
-    paddingTop
+    paddingTop,
   }: Pick<
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop"
@@ -717,7 +721,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
         height,
         paddingRight,
         paddingTop,
-        data
+        data,
       });
 
       return (
@@ -740,7 +744,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     paddingRight,
     paddingTop,
     data,
-    useColorFromDataset
+    useColorFromDataset,
   }: Pick<
     AbstractChartConfig,
     "data" | "width" | "height" | "paddingRight" | "paddingTop"
@@ -748,6 +752,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
     useColorFromDataset: AbstractChartConfig["useShadowColorFromDataset"];
   }) =>
     data.map((dataset, index) => {
+      if (dataset.withShadow == false) return;
       const xMax = this.getXMaxValues(data);
       const d =
         this.getBezierLinePoints(dataset, {
@@ -755,12 +760,14 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
           height,
           paddingRight,
           paddingTop,
-          data
+          data,
         }) +
-        ` L${paddingRight +
-          ((width - paddingRight) / xMax) *
-            (dataset.data.length - 1)},${(height / 4) * 3 +
-          paddingTop} L${paddingRight},${(height / 4) * 3 + paddingTop} Z`;
+        ` L${
+          paddingRight +
+          ((width - paddingRight) / xMax) * (dataset.data.length - 1)
+        },${(height / 4) * 3 + paddingTop} L${paddingRight},${
+          (height / 4) * 3 + paddingTop
+        } Z`;
 
       return (
         <Path
@@ -811,11 +818,11 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       onDataPointClick,
       verticalLabelRotation = 0,
       horizontalLabelRotation = 0,
-      formatYLabel = yLabel => yLabel,
-      formatXLabel = xLabel => xLabel,
+      formatYLabel = (yLabel) => yLabel,
+      formatXLabel = (xLabel) => xLabel,
       segments,
       transparent = false,
-      chartConfig
+      chartConfig,
     } = this.props;
 
     const { scrollableDotHorizontalOffset } = this.state;
@@ -826,14 +833,14 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
       paddingRight = 64,
       margin = 0,
       marginRight = 0,
-      paddingBottom = 0
+      paddingBottom = 0,
     } = style;
 
     const config = {
       width,
       height,
       verticalLabelRotation,
-      horizontalLabelRotation
+      horizontalLabelRotation,
     };
 
     const datas = this.getDatas(data.datasets);
@@ -865,7 +872,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             {this.renderDefs({
               ...config,
               ...chartConfig,
-              data: data.datasets
+              data: data.datasets,
             })}
             <G>
               {withHorizontalLines &&
@@ -874,13 +881,13 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                       ...config,
                       count: count,
                       paddingTop,
-                      paddingRight
+                      paddingRight,
                     })
                   : withOuterLines
                   ? this.renderHorizontalLine({
                       ...config,
                       paddingTop,
-                      paddingRight
+                      paddingRight,
                     })
                   : null)}
             </G>
@@ -893,7 +900,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   paddingTop: paddingTop as number,
                   paddingRight: paddingRight as number,
                   formatYLabel,
-                  decimalPlaces: chartConfig.decimalPlaces
+                  decimalPlaces: chartConfig.decimalPlaces,
                 })}
             </G>
             <G>
@@ -903,13 +910,13 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                       ...config,
                       data: data.datasets[0].data,
                       paddingTop: paddingTop as number,
-                      paddingRight: paddingRight as number
+                      paddingRight: paddingRight as number,
                     })
                   : withOuterLines
                   ? this.renderVerticalLine({
                       ...config,
                       paddingTop: paddingTop as number,
-                      paddingRight: paddingRight as number
+                      paddingRight: paddingRight as number,
                     })
                   : null)}
             </G>
@@ -920,7 +927,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   labels,
                   paddingTop: paddingTop as number,
                   paddingRight: paddingRight as number,
-                  formatXLabel
+                  formatXLabel,
                 })}
             </G>
             <G>
@@ -929,7 +936,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                 ...chartConfig,
                 paddingRight: paddingRight as number,
                 paddingTop: paddingTop as number,
-                data: data.datasets
+                data: data.datasets,
               })}
             </G>
             <G>
@@ -939,7 +946,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   data: data.datasets,
                   paddingRight: paddingRight as number,
                   paddingTop: paddingTop as number,
-                  useColorFromDataset: chartConfig.useShadowColorFromDataset
+                  useColorFromDataset: chartConfig.useShadowColorFromDataset,
                 })}
             </G>
             <G>
@@ -949,7 +956,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   data: data.datasets,
                   paddingTop: paddingTop as number,
                   paddingRight: paddingRight as number,
-                  onDataPointClick
+                  onDataPointClick,
                 })}
             </G>
             <G>
@@ -961,7 +968,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   paddingTop: paddingTop as number,
                   paddingRight: paddingRight as number,
                   onDataPointClick,
-                  scrollableDotHorizontalOffset
+                  scrollableDotHorizontalOffset,
                 })}
             </G>
             <G>
@@ -970,7 +977,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                   ...config,
                   data: data.datasets,
                   paddingTop,
-                  paddingRight
+                  paddingRight,
                 })}
             </G>
           </G>
@@ -981,13 +988,15 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             contentContainerStyle={{ width: width * 2 }}
             showsHorizontalScrollIndicator={false}
             scrollEventThrottle={16}
-            onScroll={Animated.event([
-              {
-                nativeEvent: {
-                  contentOffset: { x: scrollableDotHorizontalOffset }
-                }
-              }
-            ], { useNativeDriver: false }
+            onScroll={Animated.event(
+              [
+                {
+                  nativeEvent: {
+                    contentOffset: { x: scrollableDotHorizontalOffset },
+                  },
+                },
+              ],
+              { useNativeDriver: false }
             )}
             horizontal
             bounces={false}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "inlineSources": true,
     "esModuleInterop": true,
     "noErrorTruncation": true,
-    "jsx": "react-native"
+    "jsx": "react-native",
+    "types": []
   }
 }


### PR DESCRIPTION
Added new `withShadow` property to `Dataset`

- LineChart's `withShadow` is still needed in order for shadows to be rendered
- Dataset's `withShadow` will default to `true` when not set