### PR TITLE
Bugfix onDataPointClick Android physical devices

### DIFF
--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -318,7 +318,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                 ? getDotColor(x, i)
                 : this.getColor(dataset, 0.9)
             }
-            onPress={onPress}
+            onPressIn={onPress}
             {...this.getPropsForDots(x, i)}
           />,
           <Circle
@@ -328,7 +328,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             r="14"
             fill="#fff"
             fillOpacity={0}
-            onPress={onPress}
+            onPressIn={onPress}
           />,
           renderDotContent({ x: cx, y: cy, index: i, indexData: x })
         );


### PR DESCRIPTION
Since upgrading to RN 0.76, onDataPointClick doesn't really work anymore on real Android devices. (It still works in the emulator) Mostly due to the nested <G> elements.

Using onPressIn alleviates this.