### PR TITLE
Fix onDataPointClick not being triggered on LineChart dots

### DIFF
--- a/src/line-chart/LineChart.tsx
+++ b/src/line-chart/LineChart.tsx
@@ -293,7 +293,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
           ((baseHeight - this.calcHeight(x, datas, height)) / 4) * 3 +
           paddingTop;
 
-        const onPress = () => {
+        const onPressIn = () => {
           if (!onDataPointClick || hidePointsAtIndex.includes(i)) {
             return;
           }
@@ -318,7 +318,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
                 ? getDotColor(x, i)
                 : this.getColor(dataset, 0.9)
             }
-            onPress={onPress}
+            onPressIn={onPressIn}
             {...this.getPropsForDots(x, i)}
           />,
           <Circle
@@ -328,7 +328,7 @@ class LineChart extends AbstractChart<LineChartProps, LineChartState> {
             r="14"
             fill="#fff"
             fillOpacity={0}
-            onPress={onPress}
+            onPressIn={onPressIn}
           />,
           renderDotContent({ x: cx, y: cy, index: i, indexData: x })
         );


### PR DESCRIPTION
The `onDataPointClick` has stopped working in recent versions of Android/React Native. As suggested in https://github.com/software-mansion/react-native-svg/issues/1860#issuecomment-1412176255, using `onPressIn` instead of `onPress`.

✅  Tested on Android 16 Pixel 6a device.