### PR TITLE
Issue #765: Use transform instead of deprecated rotation/origin

### DIFF
--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -267,8 +267,7 @@ class AbstractChart<
             paddingTop;
       return (
         <Text
-          rotation={horizontalLabelRotation}
-          origin={`${x}, ${y}`}
+          transform={`rotate(${horizontalLabelRotation}, ${x}, ${y})`}
           key={`horizontal-label-${i}-${yLabel}`}
           x={x}
           textAnchor="end"

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -337,8 +337,7 @@ class AbstractChart<
 
       return (
         <Text
-          origin={`${x}, ${y}`}
-          rotation={verticalLabelRotation}
+          transform={`rotate(${verticalLabelRotation}, ${x}, ${y})`}
           key={`vertical-label-${i}-${label}`}
           x={x}
           y={y}


### PR DESCRIPTION
`rotation` and `origin` create the `transform-origin` property which causes the warning in #765. But these properties are deprecated:

* https://github.com/software-mansion/react-native-svg/blob/v15.15.4/src/lib/extract/types.ts#L256-L259
* https://github.com/software-mansion/react-native-svg/blob/v15.15.4/src/lib/extract/types.ts#L220-L223

Instead, if we switch to the non-deprecated `transform` option with `rotate`, then the `transform-origin` is not used and the warning goes away. So it's a win-win.